### PR TITLE
freetype2: fix patch

### DIFF
--- a/packages/freetype2-0001-ftconfig-fix-int-ptr-size-nonsense.patch
+++ b/packages/freetype2-0001-ftconfig-fix-int-ptr-size-nonsense.patch
@@ -1,16 +1,15 @@
-From 50676c0d3d11bb953345520f1fe6e552fe0f2eb6 Mon Sep 17 00:00:00 2001
-From: Martin Herkt <lachs0r@srsfckn.biz>
-Date: Sat, 22 Apr 2017 06:14:12 +0200
+From e8e18d1385287a0f159de532bdded71513b714fe Mon Sep 17 00:00:00 2001
+From: myfreeer <myfreeer@users.noreply.github.com>
+Date: Tue, 16 May 2017 10:39:21 +0800
 Subject: [PATCH] ftconfig: fix int/ptr size nonsense
 
-FT should just drop compatibility with imaginary compilers.
 ---
  builds/unix/ftconfig.in            | 8 +-------
  include/freetype/config/ftconfig.h | 8 +-------
  2 files changed, 2 insertions(+), 14 deletions(-)
 
 diff --git a/builds/unix/ftconfig.in b/builds/unix/ftconfig.in
-index b0ef313a..9b9b5c78 100644
+index abd101de..9b9b5c78 100644
 --- a/builds/unix/ftconfig.in
 +++ b/builds/unix/ftconfig.in
 @@ -365,13 +365,7 @@ FT_BEGIN_HEADER
@@ -20,7 +19,7 @@ index b0ef313a..9b9b5c78 100644
 -#ifdef _WIN64
 -  /* only 64bit Windows uses the LLP64 data model, i.e., */
 -  /* 32bit integers, 64bit pointers                      */
--#define FT_UINT_TO_POINTER( x ) (void*)(FT_UInt64)(x)
+-#define FT_UINT_TO_POINTER( x ) (void*)(unsigned __int64)(x)
 -#else
 -#define FT_UINT_TO_POINTER( x ) (void*)(unsigned long)(x)
 -#endif
@@ -29,7 +28,7 @@ index b0ef313a..9b9b5c78 100644
  
    /*************************************************************************/
 diff --git a/include/freetype/config/ftconfig.h b/include/freetype/config/ftconfig.h
-index 0a1e4db8..b3555b0b 100644
+index 889aebf5..b3555b0b 100644
 --- a/include/freetype/config/ftconfig.h
 +++ b/include/freetype/config/ftconfig.h
 @@ -333,13 +333,7 @@ FT_BEGIN_HEADER
@@ -39,7 +38,7 @@ index 0a1e4db8..b3555b0b 100644
 -#ifdef _WIN64
 -  /* only 64bit Windows uses the LLP64 data model, i.e., */
 -  /* 32bit integers, 64bit pointers                      */
--#define FT_UINT_TO_POINTER( x ) (void*)(FT_UInt64)(x)
+-#define FT_UINT_TO_POINTER( x ) (void*)(unsigned __int64)(x)
 -#else
 -#define FT_UINT_TO_POINTER( x ) (void*)(unsigned long)(x)
 -#endif
@@ -48,5 +47,5 @@ index 0a1e4db8..b3555b0b 100644
  
    /*************************************************************************/
 -- 
-2.12.2
+2.12.1
 


### PR DESCRIPTION
this should fix things like 
```
error: patch failed: builds/unix/ftconfig.in:365
error: builds/unix/ftconfig.in: patch does not apply
error: patch failed: include/freetype/config/ftconfig.h:333
error: include/freetype/config/ftconfig.h: patch does not apply
Applying: ftconfig: fix int/ptr size nonsense
Patch failed at 0001 ftconfig: fix int/ptr size nonsense
The copy of the patch that failed is found in: .git/rebase-apply/patch
When you have resolved this problem, run "git am --continue".
If you prefer to skip this patch, run "git am --skip" instead.
To restore the original branch and stop patching, run "git am --abort".
```