### PR TITLE
autobuild.sh: do not compress existing 7z archives

### DIFF
--- a/autobuild.sh
+++ b/autobuild.sh
@@ -50,7 +50,7 @@ zip() {
     cd ..
     for dir in ./mpv*$arch*; do
         if [ -d $dir ]; then
-            7z a -m0=lzma2 -mx=9 -ms=on $dir.7z $dir/*
+            7z a -m0=lzma2 -mx=9 -ms=on $dir.7z $dir/* -x!*.7z
             rm -rf $dir
         fi
     done


### PR DESCRIPTION
Before this fix any previous release 7z archive would be included in the new release archive.

For example, consider this `release` directory:

```
.rw-r--r--  26M frk frk  8 Dec  0:50 -- mpv-debug-x86_64-20171208-git-8977fe5.7z
.rw-r--r--  532 frk frk  9 Dec 15:17 -- mpv-debug-x86_64-20171209-git-1d7a746.7z
.rw-r--r--  13M frk frk  8 Dec  0:50 -- mpv-dev-x86_64-20171208-git-8977fe5.7z
.rw-r--r--  13M frk frk  9 Dec 15:17 -- mpv-dev-x86_64-20171209-git-1d7a746.7z
.rw-r--r-- 2.8M frk frk  8 Dec  0:33 -- mpv-packaging.zip
.rw-r--r--  15M frk frk  8 Dec  0:50 -- mpv-x86_64-20171208-git-8977fe5.7z
.rw-r--r--  30M frk frk  9 Dec 15:17 -- mpv-x86_64-20171209-git-1d7a746.7z
```

`mpv-x86_64-20171208-git-8977fe5.7z` is compressed and included in `mpv-x86_64-20171209-git-1d7a746.7z`.
This only affected the 'release' binaries though.