### PR TITLE
libressl: Clone tag instead of master

### DIFF
--- a/packages/libressl.cmake
+++ b/packages/libressl.cmake
@@ -1,6 +1,7 @@
 ExternalProject_Add(libressl
     GIT_REPOSITORY https://github.com/libressl-portable/portable.git
     GIT_SHALLOW 1
+    GIT_TAG v2.6.3
     PATCH_COMMAND ${EXEC} git am ${CMAKE_CURRENT_SOURCE_DIR}/libressl-*.patch
     UPDATE_COMMAND ""
     CONFIGURE_COMMAND ${EXEC} <SOURCE_DIR>/configure


### PR DESCRIPTION
The master branch of libressl/portable currently does not build, so we should clone the latest stable tag instead.

Maybe we should discuss if the stable tag isn't always preferable to the development branch on a security critical piece of software? 