### PR TITLE
lame: replace offline anonscm mirror with sourceforge

### DIFF
--- a/packages/lame.cmake
+++ b/packages/lame.cmake
@@ -1,5 +1,6 @@
 ExternalProject_Add(lame
-    GIT_REPOSITORY git://anonscm.debian.org/pkg-multimedia/lame.git
+    URL "http://download.sourceforge.net/lame/lame-3.100.tar.gz"
+    URL_HASH SHA256=ddfe36cab873794038ae2c1210557ad34857a4b6bdc515785d1da9e175b1da1e
     UPDATE_COMMAND ""
     PATCH_COMMAND ${DEBPATCH}
     CONFIGURE_COMMAND ${EXEC} <SOURCE_DIR>/configure


### PR DESCRIPTION
@shinchiro 
The debian mirror of `lame` is offline/not working anymore (since at least 2 days).

https://anonscm.debian.org/pkg-multimedia/lame.git

I replaced the git mirror with the latest official `tar.gz` release from sourceforge.