### PR TITLE
libarchive: Actually use lzo

### DIFF
--- a/packages/libarchive.cmake
+++ b/packages/libarchive.cmake
@@ -16,6 +16,7 @@ ExternalProject_Add(libarchive
         --disable-bsdtar
         --disable-bsdcat
         --disable-bsdcpio
+        --with-lzo2
         --without-xml2
         --without-cng
         --without-openssl


### PR DESCRIPTION
https://github.com/libarchive/libarchive/blob/master/configure.ac#L416

It doesn't look like we were actually using lzo as it's disabled by default, and this is the project it seems to be intended for. If this is wrong, feel free to close.