### PR TITLE
vulkan: rebase patch

### DIFF
--- a/packages/vulkan-0001-cross-compile-static-linking-hacks.patch
+++ b/packages/vulkan-0001-cross-compile-static-linking-hacks.patch
@@ -1,20 +1,36 @@
-From f60b92ac17da1d27d5595952be47bf641a9dec10 Mon Sep 17 00:00:00 2001
-From: shinchiro <shinchiro@users.noreply.github.com>
-Date: Sat, 2 Nov 2019 03:14:06 +0800
+From 59fd269c968006687fe4537885d4272494e18cb1 Mon Sep 17 00:00:00 2001
+From: myfreeer <myfreeer@users.noreply.github.com>
+Date: Sat, 23 Nov 2019 12:28:42 +0800
 Subject: [PATCH] loader: cross-compile & static linking hacks
 
 ---
- loader/CMakeLists.txt | 14 +++++++-------
- loader/loader.c       |  4 ++++
- loader/loader.rc      |  5 ++++-
- loader/vulkan.pc.in   |  4 ++--
- 4 files changed, 17 insertions(+), 10 deletions(-)
+ CMakeLists.txt              |  1 +
+ loader/CMakeLists.txt       | 54 +++++++++++++++++++++++--------------
+ loader/loader.c             |  6 ++++-
+ loader/loader.h             |  3 +++
+ loader/loader.rc            |  5 +++-
+ loader/vk_loader_platform.h | 16 +++++++++++
+ loader/vulkan.pc.in         |  4 +--
+ tests/CMakeLists.txt        |  5 +++-
+ 8 files changed, 69 insertions(+), 25 deletions(-)
 
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d152145..d659ef8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -120,6 +120,7 @@ endif()
+ 
+ if(WIN32)
+     option(ENABLE_WIN10_ONECORE "Link the loader with OneCore umbrella libraries" OFF)
++    option(ENABLE_STATIC_LOADER "Build the loader as a static library" OFF)
+ endif()
+ 
+ option(BUILD_LOADER "Build loader" ON)
 diff --git a/loader/CMakeLists.txt b/loader/CMakeLists.txt
-index 053a20c..8a91598 100644
+index 13a36a2..0bac961 100644
 --- a/loader/CMakeLists.txt
 +++ b/loader/CMakeLists.txt
-@@ -58,7 +58,7 @@ endif()
+@@ -61,7 +61,7 @@ endif()
  set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -DDEBUG")
  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG")
  
@@ -23,7 +39,7 @@ index 053a20c..8a91598 100644
      # Use static MSVCRT libraries
      foreach(configuration
              in
-@@ -125,7 +125,7 @@ set(ASM_FAILURE_MSG "The build will fall back on building with C code\n")
+@@ -128,7 +128,7 @@ set(ASM_FAILURE_MSG "The build will fall back on building with C code\n")
  set(ASM_FAILURE_MSG "${ASM_FAILURE_MSG}Note that this may be unsafe, as the C code requires tail-call optimizations to remove")
  set(ASM_FAILURE_MSG "${ASM_FAILURE_MSG} the stack frame for certain calls. If the compiler does not do this, then unknown device")
  set(ASM_FAILURE_MSG "${ASM_FAILURE_MSG} extensions will suffer from a corrupted stack.")
@@ -32,7 +48,7 @@ index 053a20c..8a91598 100644
      enable_language(ASM_MASM)
      if(CMAKE_ASM_MASM_COMPILER_WORKS)
          if(NOT CMAKE_CL_64)
-@@ -174,7 +174,7 @@ else(UNIX AND NOT APPLE) # i.e.: Linux
+@@ -177,7 +177,7 @@ else(UNIX AND NOT APPLE) # i.e.: Linux
      endif()
  endif()
  
@@ -41,7 +57,52 @@ index 053a20c..8a91598 100644
      add_library(loader-norm OBJECT ${NORMAL_LOADER_SRCS} dirent_on_windows.c dxgi_loader.c)
      target_compile_options(loader-norm PUBLIC "$<$<CONFIG:DEBUG>:${LOCAL_C_FLAGS_DBG}>")
      target_compile_options(loader-norm PUBLIC ${MSVC_LOADER_COMPILE_OPTIONS})
-@@ -231,14 +231,16 @@ else()
+@@ -189,19 +189,31 @@ if(WIN32)
+     target_compile_options(loader-opt PUBLIC ${MSVC_LOADER_COMPILE_OPTIONS})
+     target_include_directories(loader-opt PRIVATE "$<TARGET_PROPERTY:Vulkan::Headers,INTERFACE_INCLUDE_DIRECTORIES>")
+ 
+-    add_library(vulkan
+-                SHARED
+-                $<TARGET_OBJECTS:loader-opt>
+-                $<TARGET_OBJECTS:loader-norm>
+-                $<TARGET_OBJECTS:loader-unknown-chain>
+-                ${CMAKE_CURRENT_SOURCE_DIR}/vulkan-1.def
+-                ${CMAKE_CURRENT_SOURCE_DIR}/loader.rc)
+-    set_target_properties(vulkan
+-                          PROPERTIES LINK_FLAGS_DEBUG
+-                                     "/ignore:4098"
+-                                     OUTPUT_NAME
+-                                     vulkan-1)
+-    target_link_libraries(vulkan Vulkan::Headers)
++    if(NOT ENABLE_STATIC_LOADER)
++        target_compile_definitions(loader-norm PUBLIC LOADER_DYNAMIC_LIB)
++        target_compile_definitions(loader-opt PUBLIC LOADER_DYNAMIC_LIB)
++
++        add_library(vulkan
++                    SHARED
++                    $<TARGET_OBJECTS:loader-opt>
++                    $<TARGET_OBJECTS:loader-norm>
++                    $<TARGET_OBJECTS:loader-unknown-chain>
++                    ${CMAKE_CURRENT_SOURCE_DIR}/vulkan-1.def
++                    ${CMAKE_CURRENT_SOURCE_DIR}/loader.rc)
++        set_target_properties(vulkan
++                              PROPERTIES LINK_FLAGS_DEBUG
++                                         "/ignore:4098"
++                                         OUTPUT_NAME
++                                         vulkan-1)
++        target_link_libraries(vulkan Vulkan::Headers)
++    else()
++        add_library(vulkan
++                    STATIC
++                    $<TARGET_OBJECTS:loader-opt>
++                    $<TARGET_OBJECTS:loader-norm>
++                    $<TARGET_OBJECTS:loader-unknown-chain>)
++        set_target_properties(vulkan PROPERTIES OUTPUT_NAME VKstatic.1)
++    endif()
+ 
+     if(ENABLE_WIN10_ONECORE)
+         target_link_libraries(vulkan OneCoreUAP.lib LIBCMT.LIB LIBCMTD.LIB LIBVCRUNTIME.LIB LIBUCRT.LIB)
+@@ -222,13 +234,16 @@ else()
          set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-typedef-redefinition")
      endif()
  
@@ -49,7 +110,7 @@ index 053a20c..8a91598 100644
 +    add_library(vulkan ${NORMAL_LOADER_SRCS} ${OPT_LOADER_SRCS} dxgi_loader.c)
      add_dependencies(vulkan loader_asm_gen_files)
 +    if (NOT ENABLE_STATIC_LOADER)
-     target_compile_definitions(vulkan PUBLIC LOADER_DYNAMIC_LIB)
++    target_compile_definitions(vulkan PUBLIC LOADER_DYNAMIC_LIB)
      set_target_properties(vulkan
                            PROPERTIES SOVERSION
                                       "1"
@@ -59,7 +120,15 @@ index 053a20c..8a91598 100644
      target_link_libraries(vulkan ${CMAKE_DL_LIBS} pthread m)
      target_link_libraries(vulkan Vulkan::Headers)
  
-@@ -297,9 +299,7 @@ else()
+@@ -256,6 +271,7 @@ else()
+             ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan.hpp)
+         add_library(vulkan-framework SHARED ${NORMAL_LOADER_SRCS} ${OPT_LOADER_SRCS} ${FRAMEWORK_HEADERS})
+         add_dependencies(vulkan-framework loader_asm_gen_files)
++        target_compile_definitions(vulkan-framework PUBLIC LOADER_DYNAMIC_LIB)
+         target_link_libraries(vulkan-framework -ldl -lpthread -lm "-framework CoreFoundation")
+         target_link_libraries(vulkan-framework Vulkan::Headers)
+ 
+@@ -286,9 +302,7 @@ else()
          include(FindPkgConfig QUIET)
          if(PKG_CONFIG_FOUND)
              set(VK_API_VERSION "${VulkanHeaders_VERSION_MAJOR}.${VulkanHeaders_VERSION_MINOR}.${VulkanHeaders_VERSION_PATCH}")
@@ -71,10 +140,10 @@ index 053a20c..8a91598 100644
              install(FILES "${CMAKE_CURRENT_BINARY_DIR}/vulkan.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
          endif()
 diff --git a/loader/loader.c b/loader/loader.c
-index 398c44b..e78432e 100644
+index c61649d..4186d06 100644
 --- a/loader/loader.c
 +++ b/loader/loader.c
-@@ -672,6 +672,10 @@ out:
+@@ -671,6 +671,10 @@ out:
  //
  // *reg_data contains a string list of filenames as pointer.
  // When done using the returned string list, the caller should free the pointer.
@@ -85,6 +154,29 @@ index 398c44b..e78432e 100644
  VkResult loaderGetDeviceRegistryFiles(const struct loader_instance *inst, char **reg_data, PDWORD reg_data_size,
                                        LPCSTR value_name) {
      static const wchar_t *softwareComponentGUID = L"{5c4c3332-344d-483c-8739-259e934c9cc8}";
+@@ -7368,7 +7372,7 @@ out:
+     return result;
+ }
+ 
+-#if defined(_WIN32)
++#if defined(_WIN32) && defined(LOADER_DYNAMIC_LIB)
+ BOOL WINAPI DllMain(HINSTANCE hinst, DWORD reason, LPVOID reserved) {
+     switch (reason) {
+         case DLL_PROCESS_ATTACH:
+diff --git a/loader/loader.h b/loader/loader.h
+index 40bb23b..8d6b4c4 100644
+--- a/loader/loader.h
++++ b/loader/loader.h
+@@ -419,6 +419,9 @@ static inline void loader_init_dispatch(void *obj, const void *data) {
+ // Global variables used across files
+ extern struct loader_struct loader;
+ extern THREAD_LOCAL_DECL struct loader_instance *tls_instance;
++#if defined(_WIN32) && !defined(LOADER_DYNAMIC_LIB)
++extern LOADER_PLATFORM_THREAD_ONCE_DEFINITION(once_init);
++#endif
+ extern loader_platform_thread_mutex loader_lock;
+ extern loader_platform_thread_mutex loader_json_lock;
+ 
 diff --git a/loader/loader.rc b/loader/loader.rc
 index f705126..831ccb9 100755
 --- a/loader/loader.rc
@@ -102,6 +194,36 @@ index f705126..831ccb9 100755
  
  #define VER_FILE_VERSION            VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH, VERSION_BUILDNO
  
+diff --git a/loader/vk_loader_platform.h b/loader/vk_loader_platform.h
+index b39891a..2ffda55 100644
+--- a/loader/vk_loader_platform.h
++++ b/loader/vk_loader_platform.h
+@@ -355,9 +355,25 @@ typedef HANDLE loader_platform_thread;
+ // The once init functionality is not used when building a DLL on Windows. This is because there is no way to clean up the
+ // resources allocated by anything allocated by once init. This isn't a problem for static libraries, but it is for dynamic
+ // ones. When building a DLL, we use DllMain() instead to allow properly cleaning up resources.
++#if defined(LOADER_DYNAMIC_LIB)
+ #define LOADER_PLATFORM_THREAD_ONCE_DECLARATION(var)
+ #define LOADER_PLATFORM_THREAD_ONCE_DEFINITION(var)
+ #define LOADER_PLATFORM_THREAD_ONCE(ctl, func)
++#else
++#define LOADER_PLATFORM_THREAD_ONCE_DECLARATION(var) INIT_ONCE var = INIT_ONCE_STATIC_INIT;
++#define LOADER_PLATFORM_THREAD_ONCE_DEFINITION(var) INIT_ONCE var;
++#define LOADER_PLATFORM_THREAD_ONCE(ctl, func) loader_platform_thread_once_fn(ctl, func)
++static BOOL CALLBACK InitFuncWrapper(PINIT_ONCE InitOnce, PVOID Parameter, PVOID *Context) {
++    void (*func)(void) = (void (*)(void))Parameter;
++    func();
++    return TRUE;
++}
++static void loader_platform_thread_once_fn(void *ctl, void (*func)(void)) {
++    assert(func != NULL);
++    assert(ctl != NULL);
++    InitOnceExecuteOnce((PINIT_ONCE)ctl, InitFuncWrapper, (void *)func, NULL);
++}
++#endif
+ 
+ // Thread IDs:
+ typedef DWORD loader_platform_thread_id;
 diff --git a/loader/vulkan.pc.in b/loader/vulkan.pc.in
 index 2ce5aea..6e89703 100644
 --- a/loader/vulkan.pc.in
@@ -115,6 +237,29 @@ index 2ce5aea..6e89703 100644
  includedir=${prefix}/include
  
  Name: @CMAKE_PROJECT_NAME@
+diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
+index d9418e5..1d7bc17 100644
+--- a/tests/CMakeLists.txt
++++ b/tests/CMakeLists.txt
+@@ -105,6 +105,9 @@ else()
+ endif()
+ 
+ target_link_libraries(vk_loader_validation_tests "${LOADER_LIB}" gtest gtest_main)
++if(BUILD_LOADER AND ENABLE_STATIC_LOADER)
++    set_target_properties(vk_loader_validation_tests PROPERTIES LINK_FLAGS "/ignore:4098")
++endif()
+ 
+ # Copy loader and googletest (gtest) libs to test dir so the test executable can find them.
+ if(WIN32)
+@@ -124,7 +127,7 @@ if(WIN32)
+                        COMMAND xcopy /Y /I ${GTEST_COPY_SRC1} ${GTEST_COPY_DEST}
+                        COMMAND xcopy /Y /I ${GTEST_COPY_SRC2} ${GTEST_COPY_DEST})
+     # Copy the loader shared lib (if built) to the test application directory so the test app finds it.
+-    if(TARGET vulkan)
++    if((NOT ENABLE_STATIC_LOADER) AND TARGET vulkan)
+         add_custom_command(TARGET vk_loader_validation_tests POST_BUILD
+                            COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:vulkan> $<TARGET_FILE_DIR:vk_loader_validation_tests>)
+     endif()
 -- 
-2.17.1
+2.23.0
 


### PR DESCRIPTION
This patch would revert changes in upstream commit 08d344208e60e0bb8c8fbe25b9b1f2bf63801e2f and 161b28c1e9a9894ca11f67fc9593dbcf64866bfe, plus the original patch.

This should workaround and close https://github.com/shinchiro/mpv-winbuild-cmake/issues/51