### PR TITLE
mpv: re-enable PDF build of the manual

### DIFF
--- a/packages/mpv.cmake
+++ b/packages/mpv.cmake
@@ -30,6 +30,7 @@ ExternalProject_Add(mpv
         DEST_OS=win32
         <SOURCE_DIR>/waf configure
         --enable-static-build
+        --enable-pdf-build
         --disable-manpage-build
         --enable-libmpv-shared
         --enable-lua
@@ -74,7 +75,7 @@ ExternalProject_Add_Step(mpv copy-binary
     DEPENDEES strip-binary
     COMMAND ${CMAKE_COMMAND} -E copy <SOURCE_DIR>/build/mpv.exe ${CMAKE_CURRENT_BINARY_DIR}/mpv-package/mpv.exe
     COMMAND ${CMAKE_COMMAND} -E copy <SOURCE_DIR>/build/mpv.com ${CMAKE_CURRENT_BINARY_DIR}/mpv-package/mpv.com
-
+    COMMAND ${CMAKE_COMMAND} -E copy <SOURCE_DIR>/build/DOCS/man/mpv.pdf ${CMAKE_CURRENT_BINARY_DIR}/mpv-package/doc/manual.pdf
     COMMAND ${CMAKE_COMMAND} -E copy <SOURCE_DIR>/build/mpv.debug ${CMAKE_CURRENT_BINARY_DIR}/mpv-debug/mpv.debug
 
     COMMAND ${CMAKE_COMMAND} -E copy <SOURCE_DIR>/build/mpv-1.dll ${CMAKE_CURRENT_BINARY_DIR}/mpv-dev/mpv-1.dll


### PR DESCRIPTION
At this date, it builds successfully yet again