### PR TITLE
harfbuzz: update git tag to main

### DIFF
--- a/packages/harfbuzz.cmake
+++ b/packages/harfbuzz.cmake
@@ -3,6 +3,7 @@ ExternalProject_Add(harfbuzz
         freetype2
         libpng
     GIT_REPOSITORY https://github.com/harfbuzz/harfbuzz.git
+    GIT_TAG main
     GIT_SHALLOW 1
     UPDATE_COMMAND ""
     CONFIGURE_COMMAND ${EXEC} meson <BINARY_DIR> <SOURCE_DIR>


### PR DESCRIPTION
Harfbuzz looks to have changed their default branch from master to main.