### PR TITLE
fontconfig: Do not use dirent.h

### DIFF
--- a/packages/fontconfig-0003-Do-not-use-dirent.h.patch
+++ b/packages/fontconfig-0003-Do-not-use-dirent.h.patch
@@ -1,0 +1,25 @@
+From 783da283864a7423cb30563176eac6f20445dcc7 Mon Sep 17 00:00:00 2001
+From: Zhong Lufan <lufanzhong@gmail.com>
+Date: Fri, 7 Oct 2022 21:17:09 +0800
+Subject: [PATCH] Do not use dirent.h
+
+Because this causes some quirks on some partitions on Windows.
+---
+ meson.build | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index a9ec544..1bd807e 100644
+--- a/meson.build
++++ b/meson.build
+@@ -47,7 +47,6 @@ pkgmod = import('pkgconfig')
+ python3 = import('python').find_installation()
+ 
+ check_headers = [
+-  ['dirent.h'],
+   ['fcntl.h'],
+   ['stdlib.h'],
+   ['string.h'],
+-- 
+2.38.0
+


### PR DESCRIPTION
Because this causes some quirks on some partitions on Windows.

Fixes #260