### PR TITLE
expat: update to 2.5.0 and gcc: update to 12.2.1+20221022

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Alternatively, you can download the builds from [here](https://sourceforge.net/p
     - libsixel
 
 - Zip
-    - expat (2.4.9)
+    - expat (2.5.0)
     - bzip (1.0.8)
     - zlib (1.2.13)
     - xvidcore (1.3.7)

--- a/packages/expat.cmake
+++ b/packages/expat.cmake
@@ -1,6 +1,6 @@
 ExternalProject_Add(expat
-    URL https://github.com/libexpat/libexpat/releases/download/R_2_4_9/expat-2.4.9.tar.xz
-    URL_HASH SHA256=6e8c0728fe5c7cd3f93a6acce43046c5e4736c7b4b68e032e9350daa0efc0354
+    URL https://github.com/libexpat/libexpat/releases/download/R_2_5_0/expat-2.5.0.tar.xz
+    URL_HASH SHA256=ef2420f0232c087801abf705e89ae65f6257df6b7931d37846a193ef2e8cdcbe
     DOWNLOAD_DIR ${SOURCE_LOCATION}
     CONFIGURE_COMMAND ${EXEC} <SOURCE_DIR>/configure
         --host=${TARGET_ARCH}

--- a/toolchain/gcc.cmake
+++ b/toolchain/gcc.cmake
@@ -9,8 +9,8 @@ endif()
 ExternalProject_Add(gcc
     DEPENDS
         mingw-w64-headers
-    URL https://mirrorservice.org/sites/sourceware.org/pub/gcc/snapshots/12-20220924/gcc-12-20220924.tar.xz
-    URL_HASH SHA512=ba4d9e73d108088da26fbefe18d9b245b76771ffe752c2b4b31bdf38a2d0b638fbc115c377526c27311d4d7ffd4e0d236a5af5016bd364ccaa11a4989d1401e8
+    URL https://mirrorservice.org/sites/sourceware.org/pub/gcc/snapshots/12-20221022/gcc-12-20221022.tar.xz
+    URL_HASH SHA512=6b8a11b605ec75d6623d6072ad57d59865168da97ab0385506c8e5092bcc14473fbdd35177e79746efbaaffa44e45b93c4adad11c08f34e6d1935e74d3c1c75d
     DOWNLOAD_DIR ${SOURCE_LOCATION}
     CONFIGURE_COMMAND <SOURCE_DIR>/configure
         --target=${TARGET_ARCH}


### PR DESCRIPTION
Hi,

I used these two versions in the build and have no problem.

Regards,

