### PR TITLE
cmake: update policy to be backwards compatible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,9 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/custom_steps.cmake)
 
 cmake_policy(SET CMP0097 NEW)
 cmake_policy(SET CMP0114 NEW)
-cmake_policy(SET CMP0135 NEW)
+if(POLICY CMP0135)
+  cmake_policy(SET CMP0135 NEW)
+endif()
 
 if(NOT CMAKE_GENERATOR STREQUAL "Ninja")
     message(WARNING "Generator “${CMAKE_GENERATOR}” is unsupported!\nTry Ninja if you encounter problems.")


### PR DESCRIPTION
fixes #274 