### PR TITLE
add missing packages for Cygwin and MSYS2 to readme

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,11 @@ on:
         required: false
         default: true
         type: boolean
+      mpv_tarball:
+        description: 'Build latest mpv tarball'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   build_mpv:
@@ -106,14 +111,21 @@ jobs:
 
       - name: Building mpv
         id: build_mpv
-        if: ${{ steps.build_toolchain.outcome == 'success' }}
+        if: ${{ github.event.inputs.mpv_tarball == 'false' && steps.build_toolchain.outcome == 'success' }}
         continue-on-error: true
         run: |
           ninja -C build$BIT update; ninja -C build$BIT mpv
 
+      - name: Building mpv tarball
+        id: build_mpv_tarball
+        if: ${{ github.event.inputs.mpv_tarball == 'true' && steps.build_toolchain.outcome == 'success' }}
+        continue-on-error: true
+        run: |
+          ninja -C build$BIT update; ninja -C build$BIT mpv-release
+
       - name: Packaging mpv
         id: packaging_mpv
-        if: ${{ steps.build_toolchain.outcome == 'success' && steps.build_mpv.outcome == 'success' }}
+        if: ${{ steps.build_toolchain.outcome == 'success' && (steps.build_mpv.outcome == 'success' || steps.build_mpv_tarball.outcome == 'success') }}
         continue-on-error: true
         run: |
           mkdir -p release$BIT
@@ -213,11 +225,12 @@ jobs:
           put release/mpv-i686*          32bit
           put release/mpv-x86_64-[!v3]*  64bit
           put release/mpv-x86_64-v3*     64bit-v3
+          put release/mpv-*-[xi6864]*.7z release
           END
 
       - name: Uploading packages to Github release
         id: upload_packages_gh
-        if: ${{ github.event.inputs.github_release == 'true' }}
+        if: ${{ github.event.inputs.github_release == 'true' && github.event.inputs.mpv_tarball == 'false' }}
         continue-on-error: true
         env:
           SHORT_DATE: ${{ env.short_date }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,9 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/custom_steps.cmake)
 
 cmake_policy(SET CMP0097 NEW)
 cmake_policy(SET CMP0114 NEW)
-cmake_policy(SET CMP0135 NEW)
+if(POLICY CMP0135)
+  cmake_policy(SET CMP0135 NEW)
+endif()
 
 if(NOT CMAKE_GENERATOR STREQUAL "Ninja")
     message(WARNING "Generator “${CMAKE_GENERATOR}” is unsupported!\nTry Ninja if you encounter problems.")

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ These packages need to be installed first before compiling mpv:
 Don't install anything from the `mingw32` and `mingw64` repositories,
 it's better to completely disable them in `/etc/pacman.conf` just to be safe.
 
-Additionally, some packages, `re2c`, `ninja`, `ragel`, `libjpeg`, `rst2pdf` need to be [installed manually](https://gist.github.com/shinchiro/705b0afcc7b6c0accffba1bedb067abf).
+Additionally, some packages, `re2c`, `ninja`, `ragel`, `libjpeg`, `rst2pdf`, `jinja2` need to be [installed manually](https://gist.github.com/shinchiro/705b0afcc7b6c0accffba1bedb067abf).
 
 
 ## Building Software (First Time)

--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ These packages need to be installed first before compiling mpv:
 
 Download Cygwin installer and run:
 
-    setup-x86_64.exe -R "C:\cygwin64" -q --packages="bash,binutils,bzip2,cygwin,gcc-core,gcc-g++,cygwin32-gcc-core,cygwin32-gcc-g++,gzip,m4,pkgconf,make,unzip,zip,diffutils,wget,git,patch,cmake,gperf,yasm,nasm,enca,asciidoc,bison,flex,gettext-devel,mercurial,python-devel,python-docutils,docbook2X,texinfo,libmpfr-devel,libgmp-devel,libmpc-devel,libtool,autoconf2.5,automake,automake1.9,libxml2-devel,libxslt-devel"
+    setup-x86_64.exe -R "C:\cygwin64" -q --packages="bash,binutils,bzip2,cygwin,gcc-core,gcc-g++,cygwin32-gcc-core,cygwin32-gcc-g++,gzip,m4,pkgconf,make,unzip,zip,diffutils,wget,git,patch,cmake,gperf,yasm,enca,asciidoc,bison,flex,gettext-devel,mercurial,python-devel,python-docutils,docbook2X,texinfo,libmpfr-devel,libgmp-devel,libmpc-devel,libtool,autoconf2.5,automake,automake1.9,libxml2-devel,libxslt-devel,meson,libunistring5"
 
-Additionally, some packages, `re2c`, `ninja`, `ragel`, `gyp`, `rst2pdf` need to be [installed manually](https://gist.github.com/shinchiro/705b0afcc7b6c0accffba1bedb067abf).
+Additionally, some packages, `re2c`, `ninja`, `ragel`, `gyp`, `rst2pdf`, `nasm` need to be [installed manually](https://gist.github.com/shinchiro/705b0afcc7b6c0accffba1bedb067abf).
 
 ### MSYS2
 
@@ -135,7 +135,7 @@ Don't use `MSYS2 MinGW 32-bit` or `MSYS2 MinGW 64-bit` shortcuts, that's importa
 
 These packages need to be installed first before compiling mpv:
 
-    pacman -S base-devel cmake gcc yasm nasm git mercurial subversion gyp tar gmp-devel mpc-devel mpfr-devel python zlib-devel unzip zip p7zip
+    pacman -S base-devel cmake gcc yasm nasm git mercurial subversion gyp tar gmp-devel mpc-devel mpfr-devel python zlib-devel unzip zip p7zip meson libunistring5
 
 Don't install anything from the `mingw32` and `mingw64` repositories,
 it's better to completely disable them in `/etc/pacman.conf` just to be safe.

--- a/packages/mpv-release.cmake
+++ b/packages/mpv-release.cmake
@@ -38,32 +38,33 @@ ExternalProject_Add(mpv-release
         vapoursynth
         libsdl2
     URL ${LINK}
-    CONFIGURE_COMMAND ${EXEC}
-        PKG_CONFIG=pkgconf
-        TARGET=${TARGET_ARCH}
-        DEST_OS=win32
-        <SOURCE_DIR>/waf configure
-        --enable-static-build
-        --enable-pdf-build
-        --disable-manpage-build
-        --enable-libmpv-shared
-        --enable-lua
-        --enable-javascript
-        --enable-sdl2
-        --enable-libarchive
-        --enable-libbluray
-        --enable-dvdnav
-        --enable-uchardet
-        --enable-rubberband
-        --enable-lcms2
-        --enable-openal
-        --enable-spirv-cross
-        --enable-vulkan
-        --enable-vapoursynth
+    CONFIGURE_COMMAND ${EXEC} meson <BINARY_DIR> <SOURCE_DIR>
         --prefix=${MINGW_INSTALL_PREFIX}
-    BUILD_COMMAND ${EXEC} <SOURCE_DIR>/waf
+        --libdir=${MINGW_INSTALL_PREFIX}/lib
+        --cross-file=${MESON_CROSS}
+        --buildtype=release
+        --default-library=shared
+        --prefer-static
+        -Db_lto=true
+        -Db_ndebug=true
+        -Dlibmpv=true
+        -Dpdf-build=enabled
+        -Dlua=enabled
+        -Djavascript=enabled
+        -Dsdl2=enabled
+        -Dlibarchive=enabled
+        -Dlibbluray=enabled
+        -Ddvdnav=enabled
+        -Duchardet=enabled
+        -Drubberband=enabled
+        -Dlcms2=enabled
+        -Dopenal=enabled
+        -Dspirv-cross=enabled
+        -Dvulkan=enabled
+        -Dvapoursynth=enabled
+        -Degl-angle=enabled
+    BUILD_COMMAND ${EXEC} ninja -C <BINARY_DIR>
     INSTALL_COMMAND ""
-    BUILD_IN_SOURCE 1
     LOG_DOWNLOAD 1 LOG_UPDATE 1 LOG_CONFIGURE 1 LOG_BUILD 1 LOG_INSTALL 1
 )
 
@@ -77,19 +78,19 @@ ExternalProject_Add_Step(mpv-release bootstrap
 
 ExternalProject_Add_Step(mpv-release strip-binary
     DEPENDEES build
-    COMMAND ${EXEC} ${TARGET_ARCH}-objcopy --only-keep-debug <SOURCE_DIR>/build/mpv.exe <SOURCE_DIR>/build/mpv.debug
-    COMMAND ${EXEC} ${TARGET_ARCH}-strip -s <SOURCE_DIR>/build/mpv.exe
-    COMMAND ${EXEC} ${TARGET_ARCH}-objcopy --add-gnu-debuglink=<SOURCE_DIR>/build/mpv.debug <SOURCE_DIR>/build/mpv.exe
-    COMMAND ${EXEC} ${TARGET_ARCH}-strip -s <SOURCE_DIR>/build/mpv.com
-    COMMAND ${EXEC} ${TARGET_ARCH}-strip -s <SOURCE_DIR>/build/mpv-1.dll
+    COMMAND ${EXEC} ${TARGET_ARCH}-objcopy --only-keep-debug <BINARY_DIR>/mpv.exe <BINARY_DIR>/mpv.debug
+    COMMAND ${EXEC} ${TARGET_ARCH}-strip -s <BINARY_DIR>/mpv.exe
+    COMMAND ${EXEC} ${TARGET_ARCH}-objcopy --add-gnu-debuglink=<BINARY_DIR>/mpv.debug <BINARY_DIR>/mpv.exe
+    COMMAND ${EXEC} ${TARGET_ARCH}-strip -s <BINARY_DIR>/generated/mpv.com
+    COMMAND ${EXEC} ${TARGET_ARCH}-strip -s <BINARY_DIR>/libmpv-2.dll
     COMMENT "Stripping mpv binaries"
 )
 
 ExternalProject_Add_Step(mpv-release copy-binary
     DEPENDEES strip-binary
-    COMMAND ${CMAKE_COMMAND} -E copy <SOURCE_DIR>/build/mpv.exe                     ${CMAKE_CURRENT_BINARY_DIR}/mpv-package/mpv.exe
-    COMMAND ${CMAKE_COMMAND} -E copy <SOURCE_DIR>/build/mpv.com                     ${CMAKE_CURRENT_BINARY_DIR}/mpv-package/mpv.com
-    COMMAND ${CMAKE_COMMAND} -E copy <SOURCE_DIR>/build/DOCS/man/mpv.pdf            ${CMAKE_CURRENT_BINARY_DIR}/mpv-package/doc/manual.pdf
+    COMMAND ${CMAKE_COMMAND} -E copy <BINARY_DIR>/mpv.exe                           ${CMAKE_CURRENT_BINARY_DIR}/mpv-package/mpv.exe
+    COMMAND ${CMAKE_COMMAND} -E copy <BINARY_DIR>/generated/mpv.com                 ${CMAKE_CURRENT_BINARY_DIR}/mpv-package/mpv.com
+    COMMAND ${CMAKE_COMMAND} -E copy <BINARY_DIR>/mpv.pdf                           ${CMAKE_CURRENT_BINARY_DIR}/mpv-package/doc/manual.pdf
     COMMAND ${CMAKE_COMMAND} -E copy ${MINGW_INSTALL_PREFIX}/etc/fonts/fonts.conf   ${CMAKE_CURRENT_BINARY_DIR}/mpv-package/mpv/fonts.conf
     COMMENT "Copying mpv binaries and manual"
 )
@@ -104,7 +105,7 @@ mv $2 $3/mpv-\${TAG}-$4")
 ExternalProject_Add_Step(mpv-release copy-package-dir
     DEPENDEES copy-binary
     COMMAND chmod 755 ${RENAME}
-    COMMAND ${RENAME} <SOURCE_DIR> ${CMAKE_CURRENT_BINARY_DIR}/mpv-package ${CMAKE_BINARY_DIR} ${TARGET_CPU}
+    COMMAND ${RENAME} <SOURCE_DIR> ${CMAKE_CURRENT_BINARY_DIR}/mpv-package ${CMAKE_BINARY_DIR} ${TARGET_CPU}${x86_64_LEVEL}
     COMMENT "Moving mpv package folder"
     LOG 1
 )


### PR DESCRIPTION
A few packages (meson, libunistring5 and jinja2) were missing. Furthermore, the latest available version of nasm in Cygwin is 2.13.01-1, so it must be built manually under Cygwin to get a newer version.

Fixes #279 and fixes #280.