### PR TITLE
Mbed TLS 3.3.0 and python jsonschema

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,13 +105,13 @@ These packages need to be installed first before compiling mpv:
 
     pacman -S git gyp mercurial subversion ninja cmake meson ragel yasm nasm asciidoc enca gperf unzip p7zip gcc-multilib clang python-pip curl lib32-glib2
 
-    pip3 install rst2pdf mako
+    pip3 install rst2pdf mako jsonschema
 
 ### Ubuntu Linux / WSL (Windows 10)
 
     apt-get install build-essential checkinstall bison flex gettext git mercurial subversion ninja-build gyp cmake yasm nasm automake pkgconf libtool libtool-bin gcc-multilib g++-multilib clang libgmp-dev libmpfr-dev libmpc-dev libgcrypt-dev gperf ragel texinfo autopoint re2c asciidoc python3-pip docbook2x unzip p7zip-full curl
 
-    pip3 install rst2pdf meson mako
+    pip3 install rst2pdf meson mako jsonschema
 
 **Note:**
 

--- a/packages/mbedtls.cmake
+++ b/packages/mbedtls.cmake
@@ -1,6 +1,6 @@
 ExternalProject_Add(mbedtls
-    URL https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/v3.2.1.tar.gz
-    URL_HASH SHA256=d0e77a020f69ad558efc660d3106481b75bd3056d6301c31564e04a0faae88cc
+    URL https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/v3.3.0.tar.gz
+    URL_HASH SHA256=113fa84bc3cf862d56e7be0a656806a5d02448215d1e22c98176b1c372345d33
     DOWNLOAD_DIR ${SOURCE_LOCATION}
     CONFIGURE_COMMAND ${EXEC} cmake -H<SOURCE_DIR> -B<BINARY_DIR>
         -DCMAKE_INSTALL_PREFIX=${MINGW_INSTALL_PREFIX}


### PR DESCRIPTION
Mbed TLS can be upgrade to the new release v3.3.0 
jsonschema might be required to build Mbed TLS 
