### PR TITLE
packages/libplacebo: add libdovi dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Alternatively, you can download the builds from [here](https://sourceforge.net/p
     - uavs3d
     - davs2
     - libsixel
+    - libdovi
 
 - Zip
     - expat (2.5.0)

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ or for 32bit:
 
 First, you need to build toolchain. By default, it will be installed in `install` folder. This take ~20 minutes on my 4-core machine.
 
-    ninja gcc
+    ninja gcc rustup
 
 After it done, you're ready to build mpv and all its dependencies:
 

--- a/exec.in
+++ b/exec.in
@@ -1,6 +1,8 @@
 #!/bin/sh
-export PATH="@CMAKE_INSTALL_PREFIX@/bin:$PATH"
+export PATH="@CMAKE_INSTALL_PREFIX@/bin:@CMAKE_INSTALL_PREFIX@/.cargo/bin:$PATH"
 export PKG_CONFIG="pkgconf --static"
 export PKG_CONFIG_LIBDIR="@MINGW_INSTALL_PREFIX@/lib/pkgconfig"
+export RUSTUP_HOME="@CMAKE_INSTALL_PREFIX@/.rustup"
+export CARGO_HOME="@CMAKE_INSTALL_PREFIX@/.cargo"
 
 eval $*

--- a/packages/CMakeLists.txt
+++ b/packages/CMakeLists.txt
@@ -73,6 +73,7 @@ list(APPEND ep
     vulkan
     shaderc
     glad
+    libdovi
     libplacebo
     libsixel
     curl

--- a/packages/libdovi.cmake
+++ b/packages/libdovi.cmake
@@ -1,0 +1,34 @@
+if(${TARGET_CPU} MATCHES "x86_64")
+    set(libdovi_target "x86_64-pc-windows-gnu")
+else()
+    set(libdovi_target "i686-pc-windows-gnu")
+endif()
+
+ExternalProject_Add(libdovi
+    GIT_REPOSITORY https://github.com/quietvoid/dovi_tool.git
+    SOURCE_DIR ${SOURCE_LOCATION}
+    GIT_CLONE_FLAGS "--filter=tree:0"
+    GIT_TAG libdovi-3.1.1
+    UPDATE_COMMAND ""
+    PATCH_COMMAND ""
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ${EXEC} cargo cinstall
+        --manifest-path <SOURCE_DIR>/dolby_vision/Cargo.toml
+        --prefix ${MINGW_INSTALL_PREFIX}
+        --target ${libdovi_target}
+        --release
+        --library-type staticlib
+    LOG_DOWNLOAD 1 LOG_UPDATE 1
+)
+
+ExternalProject_Add_Step(libdovi delete-cache
+    DEPENDEES install
+    WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/.cargo
+    COMMAND rm -rf git registry
+    COMMENT "Delete cache"
+    LOG 1
+)
+
+force_rebuild_git(libdovi)
+cleanup(libdovi install)

--- a/packages/libplacebo.cmake
+++ b/packages/libplacebo.cmake
@@ -5,6 +5,7 @@ ExternalProject_Add(libplacebo
         shaderc
         lcms2
         glad
+        libdovi
     GIT_REPOSITORY https://github.com/haasn/libplacebo.git
     SOURCE_DIR ${SOURCE_LOCATION}
     GIT_CLONE_FLAGS "--filter=tree:0"

--- a/toolchain/CMakeLists.txt
+++ b/toolchain/CMakeLists.txt
@@ -8,6 +8,7 @@ list(APPEND ep
     winpthreads
     gendef
     widl
+    rustup
 )
 foreach(package IN LISTS ep)
     if(NOT ${SINGLE_SOURCE_LOCATION} STREQUAL "")

--- a/toolchain/rustup.cmake
+++ b/toolchain/rustup.cmake
@@ -1,0 +1,19 @@
+if(${TARGET_CPU} MATCHES "x86_64")
+    set(target "x86_64-pc-windows-gnu")
+else()
+    set(target "i686-pc-windows-gnu")
+endif()
+
+ExternalProject_Add(rustup
+    DOWNLOAD_COMMAND ""
+    UPDATE_COMMAND ""
+    SOURCE_DIR rustup-prefix/src
+    CONFIGURE_COMMAND ${EXEC}
+        curl -sSf https://sh.rustup.rs |
+        sh -s -- -y --default-toolchain stable --target ${target} --no-modify-path --profile minimal
+    BUILD_COMMAND ${EXEC} rustup update
+    INSTALL_COMMAND ${EXEC} cargo install cargo-c --profile=release-strip --features=vendored-openssl
+    LOG_CONFIGURE 1 LOG_BUILD 1 LOG_INSTALL 1
+)
+
+cleanup(rustup install)


### PR DESCRIPTION
I had done these changes very long ago before some refactors happened in this project, so it is possible that I need to update/fix things.

This adds the Rust toolchain setup, through `rustup`. As well as `cargo-c` to build `libdovi` as a C compatible library.
It is then used for `libplacebo` to link against to provide functionality to `mpv`.

For https://github.com/mpv-player/mpv/pull/11307