### PR TITLE
Revert "vulkan-header: clamp to working commit"

### DIFF
--- a/packages/vulkan-header.cmake
+++ b/packages/vulkan-header.cmake
@@ -5,7 +5,6 @@ ExternalProject_Add(vulkan-header
     UPDATE_COMMAND ""
     GIT_REMOTE_NAME origin
     GIT_TAG main
-    GIT_RESET 9c37439a7952c204150863fc35569dd864dbd599
     CMAKE_ARGS
         -DCMAKE_BUILD_TYPE=Release
         -DCMAKE_INSTALL_PREFIX=${MINGW_INSTALL_PREFIX}


### PR DESCRIPTION
This reverts commit b0c879ee169f0938264c7ce3e7d4ac9bce25bcb4.