### PR TITLE
zlib: switch to zlib-ng

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Alternatively, you can download the builds from [here](https://sourceforge.net/p
     - libzvbi
     - rav1e
     - libaribcaption
-    - zlib
+    - zlib (zlib-ng)
 
 - Zip
     - expat (2.5.0)

--- a/packages/zlib.cmake
+++ b/packages/zlib.cmake
@@ -1,5 +1,5 @@
 ExternalProject_Add(zlib
-    GIT_REPOSITORY https://github.com/madler/zlib.git
+    GIT_REPOSITORY https://github.com/zlib-ng/zlib-ng.git
     SOURCE_DIR ${SOURCE_LOCATION}
     GIT_CLONE_FLAGS "--filter=tree:0"
     UPDATE_COMMAND ""
@@ -13,9 +13,12 @@ ExternalProject_Add(zlib
         -DINSTALL_PKGCONFIG_DIR=${MINGW_INSTALL_PREFIX}/lib/pkgconfig
         -DSKIP_INSTALL_LIBRARIES=ON
         -DBUILD_SHARED_LIBS=OFF
+        -DZLIB_COMPAT=ON
+        -DZLIB_ENABLE_TESTS=OFF
+        -DZLIBNG_ENABLE_TESTS=OFF
     BUILD_COMMAND ${EXEC} ninja -C <BINARY_DIR>
     INSTALL_COMMAND ${EXEC} ninja -C <BINARY_DIR> install
-            COMMAND ${CMAKE_COMMAND} -E copy <BINARY_DIR>/libzlibstatic.a ${MINGW_INSTALL_PREFIX}/lib/libz.a
+            COMMAND ${CMAKE_COMMAND} -E copy <BINARY_DIR>/libz.a ${MINGW_INSTALL_PREFIX}/lib/libz.a
     LOG_DOWNLOAD 1 LOG_UPDATE 1 LOG_CONFIGURE 1 LOG_BUILD 1 LOG_INSTALL 1
 )
 


### PR DESCRIPTION
https://github.com/shinchiro/mpv-winbuild-cmake/issues/179
Though I'm only doing this for performance, not a bunch of CVEs.
zlib-ng has full SIMD optimizations, like AVX2/AVX512/NEON and is fully compatible with zlib.

Tested on GCC13/14/Clang16/17, ~~Clang17 seems to break zlib-ng builds due to `__cpuidex` related changes, this should be fix in the clang branch.~~