### PR TITLE
mpv,mpv-release: use thinlto for clang

### DIFF
--- a/cmake/packages_check.cmake
+++ b/cmake/packages_check.cmake
@@ -8,6 +8,7 @@ elseif(COMPILER_TOOLCHAIN STREQUAL "clang")
     set(vapoursynth_script_pkgconfig_libs "-lVSScript -Wl,-delayload=VSScript.dll")
     set(vapoursynth_manual_install_copy_lib COMMAND ${CMAKE_COMMAND} -E copy <SOURCE_DIR>/VSScript.lib ${MINGW_INSTALL_PREFIX}/lib/VSScript.lib
                                             COMMAND ${CMAKE_COMMAND} -E copy <SOURCE_DIR>/VapourSynth.lib ${MINGW_INSTALL_PREFIX}/lib/VapourSynth.lib)
+    set(mpv_lto_mode "-Db_lto_mode=thin")
 endif()
 
 if(TARGET_CPU STREQUAL "x86_64")

--- a/packages/mpv-release.cmake
+++ b/packages/mpv-release.cmake
@@ -47,6 +47,7 @@ ExternalProject_Add(mpv-release
         --default-library=shared
         --prefer-static
         -Db_lto=true
+        ${mpv_lto_mode}
         -Db_ndebug=true
         -Dlibmpv=true
         -Dpdf-build=enabled

--- a/packages/mpv.cmake
+++ b/packages/mpv.cmake
@@ -34,6 +34,7 @@ ExternalProject_Add(mpv
         --default-library=shared
         --prefer-static
         -Db_lto=true
+        ${mpv_lto_mode}
         -Db_ndebug=true
         -Dlibmpv=true
         -Dpdf-build=enabled


### PR DESCRIPTION
Without `b_lto_mode=thin`, fulllto would still be used, which is totally not worth it.