### PR TITLE
ffmpeg: enable hardcoded-tables for clang

### DIFF
--- a/cmake/packages_check.cmake
+++ b/cmake/packages_check.cmake
@@ -10,6 +10,7 @@ elseif(COMPILER_TOOLCHAIN STREQUAL "clang")
     set(vapoursynth_manual_install_copy_lib COMMAND ${CMAKE_COMMAND} -E copy <SOURCE_DIR>/VSScript.lib ${MINGW_INSTALL_PREFIX}/lib/VSScript.lib
                                             COMMAND ${CMAKE_COMMAND} -E copy <SOURCE_DIR>/VapourSynth.lib ${MINGW_INSTALL_PREFIX}/lib/VapourSynth.lib)
     set(ffmpeg_extra_libs "-fopenmp -lc++")
+    set(ffmpeg_hardcoded_tables "--enable-hardcoded-tables")
     set(mpv_lto_mode "-Db_lto_mode=thin")
 endif()
 

--- a/packages/ffmpeg.cmake
+++ b/packages/ffmpeg.cmake
@@ -53,6 +53,7 @@ ExternalProject_Add(ffmpeg
         --pkg-config-flags=--static
         --enable-cross-compile
         --enable-runtime-cpudetect
+        ${ffmpeg_hardcoded_tables}
         --enable-gpl
         --enable-version3
         --enable-nonfree


### PR DESCRIPTION
When compiling ffmpeg with clang, `--enable-hardcoded-tables` appears to provide some acceleration for certain codecs, especially when polly is enabled. In the case of ProRes decoding, it results in a 9% speed improvement. For `-march=native` build, the size of ffmpeg increases by approximately 2MB.

When compiling ffmpeg with gcc, there doesn't appear to be any performance improvement with `--enable-hardcoded-tables`, and it increases the size even more. Therefore, `--enable-hardcoded-tables` is only enabled when compiling with clang.