### PR TITLE
gcc: switch to git master 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Building toolchain
         run: |
-          if [[ ! "$(ls -A build$BIT/install/bin)" ]]; then ninja -C build$BIT gcc; fi
+          if [[ ! -x "./build$BIT/install/bin/${{ env.arch }}-w64-mingw32-gcc" ]]; then ninja -C build$BIT gcc; fi
 
       - name: Building mpv
         id: build_mpv_step

--- a/toolchain/gcc.cmake
+++ b/toolchain/gcc.cmake
@@ -1,9 +1,10 @@
 ExternalProject_Add(gcc
     DEPENDS
         mingw-w64-headers
-    URL https://mirrorservice.org/sites/sourceware.org/pub/gcc/snapshots/13-20230916/gcc-13-20230916.tar.xz
-    # https://mirrorservice.org/sites/sourceware.org/pub/gcc/snapshots/12-20221217/sha512.sum
-    URL_HASH SHA512=a6f8c2482895fb3e5682329c74d40d9c3f5c794e688fbc0a61fe97acacb14dfd03439baec47708eaa46b2ae2c6fcf8c97b5efe6cf89cffc5df74a8427b59fdd1
+    GIT_REPOSITORY https://github.com/gcc-mirror/gcc.git
+    SOURCE_DIR ${SOURCE_LOCATION}
+    GIT_CLONE_FLAGS "--filter=tree:0"
+    UPDATE_COMMAND ""
     DOWNLOAD_DIR ${SOURCE_LOCATION}
     CONFIGURE_COMMAND <SOURCE_DIR>/configure
         --target=${TARGET_ARCH}


### PR DESCRIPTION
Switch gcc to git master. gcc is much more stable compared to clang.
In addition, improved toolchain cache availability logic to prevent symlink problems from reoccurring. This can be reused in clang builds in the future.