### PR TITLE
cmake: pass -DLLVM_ENABLE_LTO to llvm.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ set(MINGW_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX}/${TARGET_ARCH} CACHE STRING "Ta
 set(SINGLE_SOURCE_LOCATION "" CACHE STRING "Repository or tarball stored path")
 set(RUSTUP_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/install_rustup" CACHE STRING "Rust toolchain path")
 option(ALWAYS_REMOVE_BUILDFILES "Always delete build files after successful compilation." OFF)
-
+set(LLVM_ENABLE_LTO "OFF" CACHE STRING "OFF, ON, Thin and Full")
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/toolchain.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/toolchain.cmake @ONLY)
 set(TOOLCHAIN_FILE ${CMAKE_CURRENT_BINARY_DIR}/toolchain.cmake)
 

--- a/toolchain/llvm/llvm.cmake
+++ b/toolchain/llvm/llvm.cmake
@@ -21,6 +21,7 @@ ExternalProject_Add(llvm
         -DLLVM_ENABLE_LIBCXX=ON
         -DLLVM_ENABLE_LLD=ON
         -DLLVM_INCLUDE_TESTS=OFF
+        -DLLVM_ENABLE_LTO=${LLVM_ENABLE_LTO}
         -DLLVM_INCLUDE_BENCHMARKS=OFF
         -DCLANG_DEFAULT_RTLIB=compiler-rt
         -DCLANG_DEFAULT_UNWINDLIB=libunwind


### PR DESCRIPTION
Since llvm itself doesn't need to build very often, it may be worthwhile to enable LTO to speed up build. 
disabled by default.