### PR TITLE
Shaderc: Remove merged upstream patch

### DIFF
--- a/packages/shaderc.cmake
+++ b/packages/shaderc.cmake
@@ -9,7 +9,6 @@ ExternalProject_Add(shaderc
     GIT_TAG main
     GIT_CLONE_FLAGS "--filter=tree:0"
     UPDATE_COMMAND ""
-    PATCH_COMMAND ${EXEC} curl -sL https://github.com/google/shaderc/pull/1356.patch | git am --3way --whitespace=fix
     CONFIGURE_COMMAND ${EXEC} cmake -H<SOURCE_DIR> -B<BINARY_DIR>
         -DCMAKE_BUILD_TYPE=Release
         -DCMAKE_INSTALL_PREFIX=${MINGW_INSTALL_PREFIX}


### PR DESCRIPTION
Shaderc has merged the patch. No needed here any more.