### PR TITLE
cmake: add CLANG_FLAGS and LLD_FLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,8 @@ option(ALWAYS_REMOVE_BUILDFILES "Always delete build files after successful comp
 set(LLVM_ENABLE_LTO "OFF" CACHE STRING "OFF, ON, Thin and Full")
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/toolchain.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/toolchain.cmake @ONLY)
 set(TOOLCHAIN_FILE ${CMAKE_CURRENT_BINARY_DIR}/toolchain.cmake)
-
+set(CLANG_FLAGS "" CACHE STRING "These flags will be added to the end of the clang args")
+set(LLD_FLAGS "" CACHE STRING "These flags will be added to the end of the lld args")
 set(COMPILER_TOOLCHAIN "gcc" CACHE STRING "gcc or clang")
 if(COMPILER_TOOLCHAIN STREQUAL "gcc")
     if(TARGET_ARCH STREQUAL "aarch64-w64-mingw32")

--- a/toolchain/llvm/llvm-compiler.in
+++ b/toolchain/llvm/llvm-compiler.in
@@ -6,4 +6,4 @@ FLAGS="$FLAGS @driver_mode@ --sysroot @MINGW_INSTALL_PREFIX@"
 FLAGS="$FLAGS -fuse-ld=@TARGET_ARCH@-lld"
 FLAGS="$FLAGS @cfi@ @opt@"
 
-"$PROG" $FLAGS "$@" @linker@
+"$PROG" $FLAGS "$@" @CLANG_FLAGS@ @linker@

--- a/toolchain/llvm/llvm-ld.in
+++ b/toolchain/llvm/llvm-ld.in
@@ -4,4 +4,4 @@ TARGET=@TARGET_ARCH@
 FLAGS="-m @ld_m_flag@"
 FLAGS="$FLAGS @opt@"
 
-"$PROG" $FLAGS "$@"
+"$PROG" $FLAGS "$@" @LLD_FLAGS@


### PR DESCRIPTION
O3 optimization will be enforced. some codec performance has been further improved, but since the binary size has also increased a lot, it is disabled by default.