### PR TITLE
gcc: switch to git master

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/toolchain.cmake.in ${CMAKE_CURRENT_BI
 set(TOOLCHAIN_FILE ${CMAKE_CURRENT_BINARY_DIR}/toolchain.cmake)
 set(CLANG_FLAGS "" CACHE STRING "These flags will be added to the end of the clang args")
 set(LLD_FLAGS "" CACHE STRING "These flags will be added to the end of the lld args")
+set(GCC_BRANCH "releases/gcc-13" CACHE STRING "branch of gcc")
 set(COMPILER_TOOLCHAIN "gcc" CACHE STRING "gcc or clang")
 if(COMPILER_TOOLCHAIN STREQUAL "gcc")
     if(TARGET_ARCH STREQUAL "aarch64-w64-mingw32")

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Once you’ve changed into that directory, run CMake, e.g.
 
 add `-DGCC_ARCH=x86-64-v3` to command-line if you want to compile gcc with new `x86-64-v3` instructions. Other value like `native`, `znver3` should work too in theory.
 
+add `-DGCC_BRANCH=master` to command-line if you want to compile gcc with master. Other value like `releases/gcc-13`, `releases/gcc-12` should work too in theory.
+
 or for 32bit:
 
     cmake -DTARGET_ARCH=i686-w64-mingw32 -G Ninja ..

--- a/toolchain/gcc.cmake
+++ b/toolchain/gcc.cmake
@@ -1,10 +1,11 @@
 ExternalProject_Add(gcc
     DEPENDS
         mingw-w64-headers
-    URL https://mirrorservice.org/sites/sourceware.org/pub/gcc/snapshots/13-20230916/gcc-13-20230916.tar.xz
-    # https://mirrorservice.org/sites/sourceware.org/pub/gcc/snapshots/12-20221217/sha512.sum
-    URL_HASH SHA512=a6f8c2482895fb3e5682329c74d40d9c3f5c794e688fbc0a61fe97acacb14dfd03439baec47708eaa46b2ae2c6fcf8c97b5efe6cf89cffc5df74a8427b59fdd1
-    DOWNLOAD_DIR ${SOURCE_LOCATION}
+    GIT_REPOSITORY https://github.com/gcc-mirror/gcc.git
+    SOURCE_DIR ${SOURCE_LOCATION}
+    GIT_TAG ${GCC_BRANCH}
+    GIT_CLONE_FLAGS "--filter=tree:0"
+    UPDATE_COMMAND ""
     CONFIGURE_COMMAND <SOURCE_DIR>/configure
         --target=${TARGET_ARCH}
         --prefix=${CMAKE_INSTALL_PREFIX}


### PR DESCRIPTION
Just like llvm. Since gcc is more stable, can use master directly.