### PR TITLE
Misc

### DIFF
--- a/.github/workflows/llvm_clang.yml
+++ b/.github/workflows/llvm_clang.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Building x86_64-v3 toolchain
         if: ${{ steps.x86_64_v3_cache.outputs.cache-matched-key != ''}}
         run: |
-          cmake -DTARGET_ARCH=x86_64-w64-mingw32 -DCOMPILER_TOOLCHAIN=clang -DGCC_ARCH=x86-64-v3 -DALWAYS_REMOVE_BUILDFILES=ON -DCMAKE_INSTALL_PREFIX=$PWD/clang_root -DMINGW_INSTALL_PREFIX=$PWD/build_x86_64_v3/x86_64_v3-w64-mingw32 -DSINGLE_SOURCE_LOCATION=$PWD/src_packages -DRUSTUP_LOCATION=$PWD/clang_root/install_rustup -G Ninja -B build_x86_64_v3 -S $PWD
+          cmake -DTARGET_ARCH=x86_64-w64-mingw32 -DCOMPILER_TOOLCHAIN=clang -DGCC_ARCH=x86-64-v3 -DCLANG_FLAGS=-fcf-protection=full -DALWAYS_REMOVE_BUILDFILES=ON -DCMAKE_INSTALL_PREFIX=$PWD/clang_root -DMINGW_INSTALL_PREFIX=$PWD/build_x86_64_v3/x86_64_v3-w64-mingw32 -DSINGLE_SOURCE_LOCATION=$PWD/src_packages -DRUSTUP_LOCATION=$PWD/clang_root/install_rustup -G Ninja -B build_x86_64_v3 -S $PWD
           ninja -C build_x86_64_v3 rebuild_cache
           ninja -C build_x86_64_v3 llvm-clang
 

--- a/.github/workflows/mpv_clang.yml
+++ b/.github/workflows/mpv_clang.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Downloading source
         run: |
-          if [[ $BIT == x86_64_v3 ]]; then echo "x86_64_v3_ARCH=-DGCC_ARCH=x86-64-v3" >> $GITHUB_ENV; fi
+          if [[ $BIT == x86_64_v3 ]]; then echo "x86_64_v3_ARCH=-DGCC_ARCH=x86-64-v3 -DCLANG_FLAGS=-fcf-protection=full" >> $GITHUB_ENV; fi
           cmake -DTARGET_ARCH=${{ env.arch }}-w64-mingw32 -DCOMPILER_TOOLCHAIN=clang ${{ env.x86_64_v3_ARCH }} -DALWAYS_REMOVE_BUILDFILES=ON -DCMAKE_INSTALL_PREFIX=$PWD/clang_root -DMINGW_INSTALL_PREFIX=$PWD/build_$BIT/$BIT-w64-mingw32 -DSINGLE_SOURCE_LOCATION=$PWD/src_packages -DRUSTUP_LOCATION=$PWD/clang_root/install_rustup -G Ninja -B build_$BIT -S $PWD
           ninja -C build_$BIT rebuild_cache
           ninja -C build_$BIT download || true

--- a/toolchain/llvm/llvm-clang.cmake
+++ b/toolchain/llvm/llvm-clang.cmake
@@ -4,6 +4,7 @@ ExternalProject_Add(llvm-clang
         winpthreads
         gendef
         llvm-openmp
+        rustup
     DOWNLOAD_COMMAND ""
     SOURCE_DIR ${SOURCE_LOCATION}
     UPDATE_COMMAND ""


### PR DESCRIPTION
Since AArch64 is currently disabled, it is safe to auto build the rust toolchain.

fcf-protection=full does not cause problems in haswell+(x86-64-v3), so it is safe to enable this free hardening flag.