### PR TITLE
llvm: set -march=native

### DIFF
--- a/toolchain/llvm/llvm.cmake
+++ b/toolchain/llvm/llvm.cmake
@@ -13,6 +13,8 @@ ExternalProject_Add(llvm
         -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
         -DCMAKE_C_COMPILER=clang
         -DCMAKE_CXX_COMPILER=clang++
+        -DCMAKE_C_FLAGS='-march=native'
+        -DCMAKE_CXX_FLAGS='-march=native'
         -DLLVM_ENABLE_ASSERTIONS=OFF
         -DLLVM_ENABLE_PROJECTS='clang,lld,polly'
         -DLLVM_TARGETS_TO_BUILD='X86,NVPTX'


### PR DESCRIPTION
Due to the various hard-coded absolute paths, the build directory is non-migratable, and no one should attempt to run the toolchain on another machine, so it is safe to set `-march=native` for llvm itself. Runtime library does not use `-march=native` to build.