### PR TITLE
ffmpeg: disable ffprobe and ffplay

### DIFF
--- a/packages/ffmpeg.cmake
+++ b/packages/ffmpeg.cmake
@@ -105,6 +105,8 @@ ExternalProject_Add(ffmpeg
         --enable-nvenc
         --enable-amf
         --disable-doc
+        --disable-ffplay
+        --disable-ffprobe
         --disable-vaapi
         --disable-vdpau
         --disable-videotoolbox


### PR DESCRIPTION
It doesn't make much sense on multicore systems, but for 1C2T system like GHA, it can speed up linking.