### PR TITLE
mpv: remove libplacebo option

### DIFF
--- a/packages/mpv.cmake
+++ b/packages/mpv.cmake
@@ -51,7 +51,6 @@ ExternalProject_Add(mpv
         -Dopenal=enabled
         -Dspirv-cross=enabled
         -Dvulkan=enabled
-        -Dlibplacebo=enabled
         -Dvapoursynth=enabled
         -Degl-angle=enabled
     BUILD_COMMAND ${EXEC} ninja -C <BINARY_DIR>


### PR DESCRIPTION
https://github.com/mpv-player/mpv/commit/f5ca11e12bc55d14bd6895b619c4abfd470c6452
Otherwise, meson will complain: `Unknown options: "libplacebo"`