### PR TITLE
clang: use --ld-path

### DIFF
--- a/toolchain/llvm/llvm-compiler.in
+++ b/toolchain/llvm/llvm-compiler.in
@@ -3,8 +3,9 @@ PROG=@CMAKE_INSTALL_PREFIX@/bin/@clang_compiler@
 TARGET=@TARGET_ARCH@
 FLAGS="$FLAGS -target $TARGET -march=@GCC_ARCH@ -mtune=@M_TUNE@"
 FLAGS="$FLAGS @driver_mode@ --sysroot @MINGW_INSTALL_PREFIX@"
-FLAGS="$FLAGS -fuse-ld=@TARGET_ARCH@-lld"
+FLAGS="$FLAGS -fuse-ld=lld --ld-path=@TARGET_ARCH@-ld"
 FLAGS="$FLAGS @cfi@ @opt@"
 FLAGS="$FLAGS -gcodeview"
+FLAGS="$FLAGS -Wno-error=unused-command-line-argument -Wno-unused-command-line-argument"
 
-"$PROG" $FLAGS "$@" @CLANG_FLAGS@ @linker@
+"$PROG" "$@" $FLAGS @CLANG_FLAGS@ @linker@

--- a/toolchain/llvm/llvm-wrapper.cmake
+++ b/toolchain/llvm/llvm-wrapper.cmake
@@ -21,7 +21,6 @@ ExternalProject_Add(llvm-wrapper
     COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_INSTALL_PREFIX}/bin/llvm-readelf   ${CMAKE_INSTALL_PREFIX}/bin/${TARGET_ARCH}-readelf
     COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_INSTALL_PREFIX}/bin/llvm-rc        ${CMAKE_INSTALL_PREFIX}/bin/${TARGET_ARCH}-windres
     COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_INSTALL_PREFIX}/bin/llvm-addr2line ${CMAKE_INSTALL_PREFIX}/bin/${TARGET_ARCH}-addr2line
-    COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_INSTALL_PREFIX}/bin/${TARGET_ARCH}-ld ${CMAKE_INSTALL_PREFIX}/bin/ld.${TARGET_ARCH}-lld
     COMMAND ${CMAKE_COMMAND} -E create_symlink ${PKGCONFIG} ${CMAKE_INSTALL_PREFIX}/bin/${TARGET_ARCH}-pkg-config
     COMMAND ${CMAKE_COMMAND} -E create_symlink ${PKGCONFIG} ${CMAKE_INSTALL_PREFIX}/bin/${TARGET_ARCH}-pkgconf
     INSTALL_COMMAND ""


### PR DESCRIPTION
According to the llvm people, this is the correct operation, otherwise llvm wouldn't think the linker is lld, which would cause LTO to fail. Oddly enough, mpv's LTO is not affected at all. This is mostly in preparation for future full packages LTO.