### PR TITLE
openal-soft: reset to working commit

### DIFF
--- a/packages/openal-soft.cmake
+++ b/packages/openal-soft.cmake
@@ -2,6 +2,9 @@ ExternalProject_Add(openal-soft
     GIT_REPOSITORY https://github.com/kcat/openal-soft.git
     SOURCE_DIR ${SOURCE_LOCATION}
     GIT_CLONE_FLAGS "--filter=tree:0"
+    GIT_REMOTE_NAME origin
+    GIT_TAG master
+    GIT_RESET d44112514d84614af6c16ec48d9450706da3b335
     UPDATE_COMMAND ""
     CONFIGURE_COMMAND ${EXEC} cmake -H<SOURCE_DIR> -B<BINARY_DIR>
         -G Ninja


### PR DESCRIPTION
llvm has no libc++ mathematical special functions implementation plan in the short term, we can only pray openal-soft will provide fallback for this, otherwise we will have to reset openal-soft to this commit forever.