### PR TITLE
libvpx: don't strip libs

### DIFF
--- a/packages/libvpx.cmake
+++ b/packages/libvpx.cmake
@@ -22,10 +22,10 @@ ExternalProject_Add(libvpx
         --disable-decode-perf-tests
         --disable-encode-perf-tests
         --as=yasm
+        --enable-debug
         --enable-vp9-highbitdepth
     BUILD_COMMAND ${MAKE}
     INSTALL_COMMAND ${MAKE} install
-            COMMAND ${EXEC} ${TARGET_ARCH}-ranlib ${MINGW_INSTALL_PREFIX}/lib/libvpx.a
     LOG_DOWNLOAD 1 LOG_UPDATE 1 LOG_CONFIGURE 1 LOG_BUILD 1 LOG_INSTALL 1
 )
 


### PR DESCRIPTION
Simplified the INSTALL step and fixed LTO problem.