### PR TITLE
ogg,vorbis,speex: switch to github mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,12 +228,12 @@ to update flags which will pass on gcc, g++ and etc.
     - openssl
     - mesa
     - libsdl2
+    - speex
 
 - Zip
     - bzip (1.0.8)
     - xvidcore (1.3.7)
     - vorbis (1.3.7)
-    - speex (1.2.1)
     - ogg (1.3.5)
     - lzo (2.10)
     - libopenmpt (0.7.3)

--- a/README.md
+++ b/README.md
@@ -230,11 +230,11 @@ to update flags which will pass on gcc, g++ and etc.
     - libsdl2
     - speex
     - vorbis
+    - ogg
 
 - Zip
     - bzip (1.0.8)
     - xvidcore (1.3.7)
-    - ogg (1.3.5)
     - lzo (2.10)
     - libopenmpt (0.7.3)
     - libiconv (1.17)

--- a/README.md
+++ b/README.md
@@ -229,11 +229,11 @@ to update flags which will pass on gcc, g++ and etc.
     - mesa
     - libsdl2
     - speex
+    - vorbis
 
 - Zip
     - bzip (1.0.8)
     - xvidcore (1.3.7)
-    - vorbis (1.3.7)
     - ogg (1.3.5)
     - lzo (2.10)
     - libopenmpt (0.7.3)

--- a/packages/lcms2.cmake
+++ b/packages/lcms2.cmake
@@ -20,4 +20,5 @@ ExternalProject_Add(lcms2
 )
 
 force_rebuild_git(lcms2)
+force_meson_configure(lcms2)
 cleanup(lcms2 install)

--- a/packages/ogg.cmake
+++ b/packages/ogg.cmake
@@ -1,16 +1,19 @@
 ExternalProject_Add(ogg
-    URL https://ftp.osuosl.org/pub/xiph/releases/ogg/libogg-1.3.5.tar.xz
-    URL_HASH SHA256=c4d91be36fc8e54deae7575241e03f4211eb102afb3fc0775fbbc1b740016705
-    DOWNLOAD_DIR ${SOURCE_LOCATION}
+    GIT_REPOSITORY https://github.com/xiph/ogg.git
+    SOURCE_DIR ${SOURCE_LOCATION}
+    GIT_CLONE_FLAGS "--filter=tree:0"
     UPDATE_COMMAND ""
-    CONFIGURE_COMMAND ${EXEC} CONF=1 autoreconf -fi && <SOURCE_DIR>/configure
-        --host=${TARGET_ARCH}
-        --prefix=${MINGW_INSTALL_PREFIX}
-        --disable-shared
-    BUILD_COMMAND ${MAKE}
-    INSTALL_COMMAND ${MAKE} install
-    BUILD_IN_SOURCE 1
+    CONFIGURE_COMMAND ${EXEC} CONF=1 cmake -H<SOURCE_DIR> -B<BINARY_DIR>
+        -G Ninja
+        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE}
+        -DCMAKE_INSTALL_PREFIX=${MINGW_INSTALL_PREFIX}
+        -DCMAKE_FIND_ROOT_PATH=${MINGW_INSTALL_PREFIX}
+        -DBUILD_SHARED_LIBS=OFF
+    BUILD_COMMAND ${EXEC} ninja -C <BINARY_DIR>
+    INSTALL_COMMAND ${EXEC} ninja -C <BINARY_DIR> install
     LOG_DOWNLOAD 1 LOG_UPDATE 1 LOG_CONFIGURE 1 LOG_BUILD 1 LOG_INSTALL 1
 )
 
+force_rebuild_git(ogg)
 cleanup(ogg install)

--- a/packages/speex.cmake
+++ b/packages/speex.cmake
@@ -1,19 +1,23 @@
 ExternalProject_Add(speex
-    DEPENDS ogg
-    URL "https://ftp.osuosl.org/pub/xiph/releases/speex/speex-1.2.1.tar.gz"
-    URL_HASH SHA256=4b44d4f2b38a370a2d98a78329fefc56a0cf93d1c1be70029217baae6628feea
-    DOWNLOAD_DIR ${SOURCE_LOCATION}
+    DEPENDS
+        ogg 
+    GIT_REPOSITORY https://github.com/xiph/speex.git
+    SOURCE_DIR ${SOURCE_LOCATION}
+    GIT_CLONE_FLAGS "--filter=tree:0"
     UPDATE_COMMAND ""
-    CONFIGURE_COMMAND ${EXEC} CONF=1
-        LIBS=-lwinmm
-        autoreconf -fi && <SOURCE_DIR>/configure
-        --host=${TARGET_ARCH}
+    CONFIGURE_COMMAND ${EXEC} CONF=1 meson <BINARY_DIR> <SOURCE_DIR>
         --prefix=${MINGW_INSTALL_PREFIX}
-        --disable-shared
-    BUILD_COMMAND ${MAKE}
-    INSTALL_COMMAND ${MAKE} install
-    BUILD_IN_SOURCE 1
+        --libdir=${MINGW_INSTALL_PREFIX}/lib
+        --cross-file=${MESON_CROSS}
+        --buildtype=release
+        --default-library=static
+        -Dtest-binaries=disabled
+        -Dtools=disabled
+    BUILD_COMMAND ${EXEC} ninja -C <BINARY_DIR>
+    INSTALL_COMMAND ${EXEC} ninja -C <BINARY_DIR> install
     LOG_DOWNLOAD 1 LOG_UPDATE 1 LOG_CONFIGURE 1 LOG_BUILD 1 LOG_INSTALL 1
 )
 
+force_rebuild_git(speex)
 cleanup(speex install)
+force_meson_configure(speex)

--- a/packages/vorbis.cmake
+++ b/packages/vorbis.cmake
@@ -1,16 +1,21 @@
 ExternalProject_Add(vorbis
-    DEPENDS ogg
-    URL "https://downloads.xiph.org/releases/vorbis/libvorbis-1.3.7.tar.xz"
-    URL_HASH SHA256=b33cc4934322bcbf6efcbacf49e3ca01aadbea4114ec9589d1b1e9d20f72954b
-    DOWNLOAD_DIR ${SOURCE_LOCATION}
+    DEPENDS
+        ogg
+    GIT_REPOSITORY https://github.com/xiph/vorbis.git
+    SOURCE_DIR ${SOURCE_LOCATION}
+    GIT_CLONE_FLAGS "--filter=tree:0"
     UPDATE_COMMAND ""
-    CONFIGURE_COMMAND ${EXEC} CONF=1 <SOURCE_DIR>/configure
-        --host=${TARGET_ARCH}
-        --prefix=${MINGW_INSTALL_PREFIX}
-        --disable-shared
-    BUILD_COMMAND ${MAKE}
-    INSTALL_COMMAND ${MAKE} install
+    CONFIGURE_COMMAND ${EXEC} CONF=1 cmake -H<SOURCE_DIR> -B<BINARY_DIR>
+        -G Ninja
+        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE}
+        -DCMAKE_INSTALL_PREFIX=${MINGW_INSTALL_PREFIX}
+        -DCMAKE_FIND_ROOT_PATH=${MINGW_INSTALL_PREFIX}
+        -DBUILD_SHARED_LIBS=OFF
+    BUILD_COMMAND ${EXEC} ninja -C <BINARY_DIR>
+    INSTALL_COMMAND ${EXEC} ninja -C <BINARY_DIR> install
     LOG_DOWNLOAD 1 LOG_UPDATE 1 LOG_CONFIGURE 1 LOG_BUILD 1 LOG_INSTALL 1
 )
 
+force_rebuild_git(vorbis)
 cleanup(vorbis install)


### PR DESCRIPTION
Based on #515, because speex has a fftw dependency. If you don't think need this, I can remove this change and rebase to master.