### PR TITLE
freetype2: enable brotli

### DIFF
--- a/packages/CMakeLists.txt
+++ b/packages/CMakeLists.txt
@@ -34,6 +34,7 @@ list(APPEND ep
     nettle
     mbedtls
     libxml2
+    brotli
     freetype2
     libudfread
     libbluray
@@ -55,7 +56,6 @@ list(APPEND ep
     libwebp
     vapoursynth
     libbs2b
-    brotli
     openssl
     libssh
     libsrt

--- a/packages/freetype2.cmake
+++ b/packages/freetype2.cmake
@@ -2,6 +2,7 @@ ExternalProject_Add(freetype2
     DEPENDS
         libpng
         zlib
+        brotli
     GIT_REPOSITORY https://github.com/freetype/freetype.git
     SOURCE_DIR ${SOURCE_LOCATION}
     GIT_CLONE_FLAGS "--filter=tree:0"
@@ -15,7 +16,7 @@ ExternalProject_Add(freetype2
         --default-library=static
         -Dharfbuzz=disabled
         -Dtests=disabled
-        -Dbrotli=disabled
+        -Dbrotli=enabled
         -Dzlib=enabled
         -Dpng=enabled
     BUILD_COMMAND ${EXEC} ninja -C <BINARY_DIR>


### PR DESCRIPTION
For support of WOFF2 fonts.