### PR TITLE
libssh: switch to gitlab mirror

### DIFF
--- a/packages/libssh.cmake
+++ b/packages/libssh.cmake
@@ -2,7 +2,7 @@ ExternalProject_Add(libssh
     DEPENDS
         zlib
         openssl
-    GIT_REPOSITORY https://git.libssh.org/projects/libssh.git
+    GIT_REPOSITORY https://gitlab.com/libssh/libssh-mirror.git
     SOURCE_DIR ${SOURCE_LOCATION}
     GIT_CLONE_FLAGS "--filter=tree:0"
     UPDATE_COMMAND ""


### PR DESCRIPTION
libssh's own git is still stable, not sure it's worth it.