### PR TITLE
ffmpeg: drop gmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ to update flags which will pass on gcc, g++ and etc.
     - lzo (2.10)
     - libopenmpt (0.7.3)
     - libiconv (1.17)
-    - gmp (6.3.0)
+    - ~~gmp (6.3.0)~~
     - vapoursynth (R65/R63)
     - ~~mbedtls (3.5.0)~~
     - ~~libressl (3.1.5)~~

--- a/packages/CMakeLists.txt
+++ b/packages/CMakeLists.txt
@@ -118,7 +118,7 @@ list(LENGTH ep ep_length)
 message(STATUS "Parsing ${ep_length} packages")
 
 # Exclude packages which dont depend on mpv when update
-list(APPEND removed "flac" "opusfile" "libopusenc" "opus-tools" "termcap" "readline" "cryptopp" "sqlite" "libuv" "libsodium" "megasdk" "libsixel" "curl" "libressl" "mbedtls" "nettle" "mesa")
+list(APPEND removed "flac" "opusfile" "libopusenc" "opus-tools" "termcap" "readline" "cryptopp" "sqlite" "libuv" "libsodium" "megasdk" "libsixel" "curl" "libressl" "mbedtls" "nettle" "gmp" "mesa")
 list(REMOVE_ITEM repo ${removed})
 list(REMOVE_ITEM ep ${removed})
 list(TRANSFORM repo APPEND "-force-update" OUTPUT_VARIABLE update)

--- a/packages/ffmpeg.cmake
+++ b/packages/ffmpeg.cmake
@@ -4,7 +4,6 @@ ExternalProject_Add(ffmpeg
         avisynth-headers
         nvcodec-headers
         bzip2
-        gmp
         lame
         lcms2
         openssl
@@ -63,7 +62,6 @@ ExternalProject_Add(ffmpeg
         --enable-postproc
         --enable-avisynth
         --enable-vapoursynth
-        --enable-gmp
         --enable-libass
         --enable-libbluray
         --enable-libfreetype


### PR DESCRIPTION
```
  --enable-gmp             enable gmp, needed for rtmp(t)e support
                           if openssl or librtmp is not used [no]
```