### PR TITLE
ffmpeg: use svtav1 instead of rav1e

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ to update flags which will pass on gcc, g++ and etc.
     - libdovi
     - libva
     - libzvbi
-    - rav1e
+    - svtav1
     - libaribcaption
     - zlib (zlib-ng)
     - zstd

--- a/packages/CMakeLists.txt
+++ b/packages/CMakeLists.txt
@@ -79,6 +79,7 @@ list(APPEND ep
     fast_float
     libdovi
     rav1e
+    svtav1
     libplacebo
     libva
     libzvbi
@@ -118,7 +119,7 @@ list(LENGTH ep ep_length)
 message(STATUS "Parsing ${ep_length} packages")
 
 # Exclude packages which dont depend on mpv when update
-list(APPEND removed "flac" "opusfile" "libopusenc" "opus-tools" "termcap" "readline" "cryptopp" "sqlite" "libuv" "libsodium" "megasdk" "libsixel" "curl" "libressl" "mbedtls" "nettle" "gmp" "mesa")
+list(APPEND removed "flac" "opusfile" "libopusenc" "opus-tools" "termcap" "readline" "cryptopp" "sqlite" "libuv" "libsodium" "megasdk" "libsixel" "curl" "libressl" "mbedtls" "nettle" "gmp" "mesa" "rav1e")
 list(REMOVE_ITEM repo ${removed})
 list(REMOVE_ITEM ep ${removed})
 list(TRANSFORM repo APPEND "-force-update" OUTPUT_VARIABLE update)

--- a/packages/ffmpeg.cmake
+++ b/packages/ffmpeg.cmake
@@ -36,7 +36,7 @@ ExternalProject_Add(ffmpeg
         libzvbi
         libaribcaption
         aom
-        rav1e
+        svtav1
         dav1d
         vapoursynth
         uavs3d
@@ -83,7 +83,7 @@ ExternalProject_Add(ffmpeg
         --enable-libx264
         --enable-libx265
         --enable-libaom
-        --enable-librav1e
+        --enable-libsvtav1
         --enable-libdav1d
         --enable-libdavs2
         --enable-libuavs3d

--- a/packages/svtav1.cmake
+++ b/packages/svtav1.cmake
@@ -1,0 +1,26 @@
+ExternalProject_Add(svtav1
+    GIT_REPOSITORY https://gitlab.com/AOMediaCodec/SVT-AV1.git
+    SOURCE_DIR ${SOURCE_LOCATION}
+    GIT_CLONE_FLAGS "--filter=tree:0"
+    UPDATE_COMMAND ""
+    CONFIGURE_COMMAND ${EXEC} CONF=1 cmake -H<SOURCE_DIR> -B<BINARY_DIR>
+        -G Ninja
+        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE}
+        -DCMAKE_INSTALL_PREFIX=${MINGW_INSTALL_PREFIX}
+        -DCMAKE_FIND_ROOT_PATH=${MINGW_INSTALL_PREFIX}
+        -DBUILD_SHARED_LIBS=OFF
+        -DENABLE_NASM=ON
+        -DENABLE_AVX512=ON
+        -DBUILD_DEC=OFF
+        -DBUILD_TESTING=OFF
+        -DBUILD_ENC=ON
+        -DSVT_AV1_LTO=OFF
+        -DBUILD_APPS=OFF
+    BUILD_COMMAND ${EXEC} ninja -C <BINARY_DIR>
+    INSTALL_COMMAND ${EXEC} ninja -C <BINARY_DIR> install
+    LOG_DOWNLOAD 1 LOG_UPDATE 1 LOG_CONFIGURE 1 LOG_BUILD 1 LOG_INSTALL 1
+)
+
+force_rebuild_git(svtav1)
+cleanup(svtav1 install)


### PR DESCRIPTION
svtav1 is build faster, performance better, more compatible with the llvm-mingw toolchain, and supports arm64.