### PR TITLE
rav1e: set CARGO_PROFILE_RELEASE_LTO=off

### DIFF
--- a/packages/rav1e.cmake
+++ b/packages/rav1e.cmake
@@ -10,6 +10,7 @@ ExternalProject_Add(rav1e
         CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1
         CARGO_PROFILE_RELEASE_DEBUG=false
         CARGO_PROFILE_RELEASE_INCREMENTAL=false
+        CARGO_PROFILE_RELEASE_LTO=off
         ${cargo_lto_rustflags}
         cargo cinstall
         --manifest-path <SOURCE_DIR>/Cargo.toml


### PR DESCRIPTION
If LTO is enabled, RUSTFLAGS will override this.