### PR TITLE
clang: suppress -Wmissing-prototypes to fix ffmpeg compilation

### DIFF
--- a/toolchain/llvm/llvm-compiler.in
+++ b/toolchain/llvm/llvm-compiler.in
@@ -6,7 +6,7 @@ FLAGS="$FLAGS @driver_mode@ --sysroot @MINGW_INSTALL_PREFIX@"
 FLAGS="$FLAGS -fuse-ld=lld --ld-path=@TARGET_ARCH@-ld"
 FLAGS="$FLAGS @cfi@ @opt@"
 FLAGS="$FLAGS -gcodeview"
-FLAGS="$FLAGS -Wno-unused-command-line-argument"
+FLAGS="$FLAGS -Wno-unused-command-line-argument -Wno-missing-prototypes"
 
 if [ "$LTO" != "0" ] && [ "@CLANG_PACKAGES_LTO@" = "ON" ]; then
     LTO_FLAGS="-flto=thin"


### PR DESCRIPTION
Temporary compilation problem solution for ffmpeg d3d12va.
https://github.com/zhongfly/mpv-winbuild/actions/runs/7286031559