### PR TITLE
ffmpeg: remove nonfree flag

### DIFF
--- a/packages/ffmpeg.cmake
+++ b/packages/ffmpeg.cmake
@@ -58,7 +58,6 @@ ExternalProject_Add(ffmpeg
         ${ffmpeg_hardcoded_tables}
         --enable-gpl
         --enable-version3
-        --enable-nonfree
         --enable-postproc
         --enable-avisynth
         --enable-vapoursynth


### PR DESCRIPTION
"--enable-nonfree" makes ffmpeg unredistributable.But currently there are no dependencies that require this option to be enabled.

Only the following libs in ffmpeg require "--enable-nonfree":decklink,libfdk_aac,libtls.