### PR TITLE
ffmpeg: explicitly enable pthreads, disable w32threads

### DIFF
--- a/packages/ffmpeg.cmake
+++ b/packages/ffmpeg.cmake
@@ -107,6 +107,8 @@ ExternalProject_Add(ffmpeg
         --enable-amf
         --enable-openal
         --enable-opengl
+        --enable-pthreads
+        --disable-w32threads
         --disable-doc
         --disable-ffplay
         --disable-ffprobe


### PR DESCRIPTION
latest mingw-w64 fixed pthreads problem, but ffmpeg still use win32threads by default.

Note that configure may fail if toolchain has not been rebuilt recently. Rebuild toolchain will fix it (no need rebuild LLVM).