### PR TITLE
lld: use --icf=all

### DIFF
--- a/toolchain/llvm/llvm-ld.in
+++ b/toolchain/llvm/llvm-ld.in
@@ -11,7 +11,7 @@ if [ "$CONF" == "1" ]; then
 fi
 
 if [ "$GC" != "0" ]; then
-    LLD_GC="--gc-sections -Xlink=-opt:safeicf"
+    LLD_GC="--gc-sections --icf=all"
 fi
 
 "$PROG" "$@" $FLAGS $LLD_GC @LLD_FLAGS@ $SKIP_OPT


### PR DESCRIPTION
ref: https://doc.rust-lang.org/nightly/nightly-rustc/src/bootstrap/core/build_steps/compile.rs.html#916

This is the default behavior of msvc link/lld-link, so at least for Windows, --icf=all is safe. I've been using --icf=all for a couple months now and haven't noticed any problems.