### PR TITLE
vulkan-header: reset to 1.3.276

### DIFF
--- a/packages/vulkan-header.cmake
+++ b/packages/vulkan-header.cmake
@@ -5,6 +5,7 @@ ExternalProject_Add(vulkan-header
     UPDATE_COMMAND ""
     GIT_REMOTE_NAME origin
     GIT_TAG main
+    GIT_RESET ea45703
     CONFIGURE_COMMAND ${EXEC} CONF=1 cmake -H<SOURCE_DIR> -B<BINARY_DIR>
         -G Ninja
         -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
FFmpeg VK_MESA_video_decode_av1 structure conflicted with VK_KHR_video_decode_av1 structure in 1.3.277 cause build to fail, so temporarily reset to ea45703 until FFmpeg fixes the problem.