### PR TITLE
Revert "spirv-headers: clamp to working commit for shaderc"

### DIFF
--- a/packages/spirv-headers.cmake
+++ b/packages/spirv-headers.cmake
@@ -4,7 +4,6 @@ ExternalProject_Add(spirv-headers
     GIT_CLONE_FLAGS "--filter=tree:0"
     GIT_REMOTE_NAME origin
     GIT_TAG main
-    GIT_RESET b73e168
     UPDATE_COMMAND ""
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""


### PR DESCRIPTION
This reverts commit de61f9d1321a76c196b1f47b4ed76dddb883af4d.