### PR TITLE
libplacebo: add dependency spirv-cross to ensure d3d11 support

### DIFF
--- a/packages/libplacebo.cmake
+++ b/packages/libplacebo.cmake
@@ -4,6 +4,7 @@ ExternalProject_Add(libplacebo
     DEPENDS
         vulkan
         shaderc
+        spirv-cross
         lcms2
         glad
         fast_float
@@ -24,6 +25,7 @@ ExternalProject_Add(libplacebo
         --libdir=${MINGW_INSTALL_PREFIX}/lib
         --cross-file=${MESON_CROSS}
         --default-library=static
+        -Dd3d11=enabled
         -Ddebug=true
         -Db_ndebug=true
         -Doptimization=3


### PR DESCRIPTION
libplacebo checks the existence of spirv-cross to enable d3d11 support. We need to add the dependency in case libplacebo is built before spirv-cross.

Also explicitly enabled d3d11 to avoid incomplete build.