### PR TITLE
mbedtls: update to 3.6.0

### DIFF
--- a/packages/mbedtls-0001-include-cpuid.patch
+++ b/packages/mbedtls-0001-include-cpuid.patch
@@ -1,29 +1,31 @@
-From 7e76bfbcead3e11ddcc8f597719ed52f663cad12 Mon Sep 17 00:00:00 2001
-From: shinchiro <shinchiro@users.noreply.github.com>
-Date: Sun, 8 Oct 2023 01:34:27 +0800
+From 2b2a90055d2a268383baa950cc8afa74333db5ee Mon Sep 17 00:00:00 2001
+From: CharlesMengCA <CharlesMeng@outlook.com>
+Date: Sun, 21 Apr 2024 13:55:00 -0400
 Subject: [PATCH] include cpuid.h only
 
 Ref: https://github.com/Mbed-TLS/mbedtls/commit/d671917
 ---
- library/aesni.c | 4 ----
- 1 file changed, 4 deletions(-)
+ library/aesni.c | 6 ------
+ 1 file changed, 6 deletions(-)
 
 diff --git a/library/aesni.c b/library/aesni.c
-index 5f25a824..711112ba 100644
+index 8e5bd55ab..74447e57a 100644
 --- a/library/aesni.c
 +++ b/library/aesni.c
-@@ -33,11 +33,7 @@
+@@ -21,13 +21,7 @@
  #if defined(MBEDTLS_AESNI_HAVE_CODE)
  
  #if MBEDTLS_AESNI_HAVE_CODE == 2
--#if !defined(_WIN32)
+-#if defined(__GNUC__)
  #include <cpuid.h>
--#else
+-#elif defined(_MSC_VER)
 -#include <intrin.h>
+-#else
+-#error "`__cpuid` required by MBEDTLS_AESNI_C is not supported by the compiler"
 -#endif
  #include <immintrin.h>
  #endif
  
 -- 
-2.42.0
+2.43.0.windows.1
 

--- a/packages/mbedtls.cmake
+++ b/packages/mbedtls.cmake
@@ -6,7 +6,7 @@ ExternalProject_Add(mbedtls
     UPDATE_COMMAND ""
     GIT_REMOTE_NAME origin
     GIT_TAG master
-    GIT_RESET 1ec69067fa1351427f904362c1221b31538c8b57 # v3.5.0
+    GIT_RESET 2ca6c285a0dd3f33982dd57299012dacab1ff206 # v3.6.0
     CONFIGURE_COMMAND ${EXEC} CONF=1 cmake -H<SOURCE_DIR> -B<BINARY_DIR>
         -G Ninja
         -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
mbedtls-0001-include-cpuid.patch was manually re-based basing on your old patch.