### PR TITLE
packages: re-add fdk-aac

### DIFF
--- a/packages/fdk-aac.cmake
+++ b/packages/fdk-aac.cmake
@@ -1,0 +1,20 @@
+ExternalProject_Add(fdk-aac
+    GIT_REPOSITORY https://github.com/mstorsjo/fdk-aac.git
+    SOURCE_DIR ${SOURCE_LOCATION}
+    GIT_CLONE_FLAGS "--filter=tree:0"
+    UPDATE_COMMAND ""
+    CONFIGURE_COMMAND ${EXEC} CONF=1 cmake -H<SOURCE_DIR> -B<BINARY_DIR>
+        -G Ninja
+        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE}
+        -DCMAKE_INSTALL_PREFIX=${MINGW_INSTALL_PREFIX}
+        -DCMAKE_FIND_ROOT_PATH=${MINGW_INSTALL_PREFIX}
+        -DFDK_AAC_INSTALL_CMAKE_CONFIG_MODULE=ON
+        -DFDK_AAC_INSTALL_PKGCONFIG_MODULE=ON
+    BUILD_COMMAND ${EXEC} ninja -C <BINARY_DIR>
+    INSTALL_COMMAND ${EXEC} ninja -C <BINARY_DIR> install
+    LOG_DOWNLOAD 1 LOG_UPDATE 1 LOG_CONFIGURE 1 LOG_BUILD 1 LOG_INSTALL 1
+)
+
+force_rebuild_git(fdk-aac)
+cleanup(fdk-aac install)


### PR DESCRIPTION
Just add it, it's not enabled by default

Local users can enable it by themselves, and then optionally disable ffmpeg aac to use fdk-aac by default, and then enable hardcoded tables to improve performance