### PR TITLE
ci: fix x86_64_v3_ARCH being set too late in clang workflow

### DIFF
--- a/.github/workflows/mpv_clang.yml
+++ b/.github/workflows/mpv_clang.yml
@@ -51,6 +51,7 @@ jobs:
           elif [[ $BIT == "x86_64_v3" ]]; then
             echo "arch=x86_64" >> $GITHUB_ENV
             echo "x86_64_level=-v3" >> $GITHUB_ENV
+            echo "x86_64_v3_ARCH=-DGCC_ARCH=x86-64-v3" >> $GITHUB_ENV
           elif [[ $BIT == "aarch64" ]]; then
             echo "arch=aarch64" >> $GITHUB_ENV
           fi
@@ -101,7 +102,6 @@ jobs:
 
       - name: Configuring CMake & Downloading source
         run: |
-          if [[ $BIT == x86_64_v3 ]]; then echo "x86_64_v3_ARCH=-DGCC_ARCH=x86-64-v3" >> $GITHUB_ENV; fi
           cmake -DTARGET_ARCH=${{ env.arch }}-w64-mingw32 -DCOMPILER_TOOLCHAIN=clang ${{ env.x86_64_v3_ARCH }} -DCMAKE_INSTALL_PREFIX=$PWD/clang_root -DMINGW_INSTALL_PREFIX=$PWD/build_$BIT/$BIT-w64-mingw32 -DSINGLE_SOURCE_LOCATION=$PWD/src_packages -DRUSTUP_LOCATION=$PWD/clang_root/install_rustup -DENABLE_CCACHE=ON -DCLANG_PACKAGES_LTO=ON -G Ninja --fresh -B build_$BIT -S $PWD
           ninja -C build_$BIT download || true
 


### PR DESCRIPTION
it was set directly before needed which apparently is too late and therefore the environment variable is unset.
you can check this by inspecting the workflow run of `x86_64_v3` at "Configuring CMake & Downloading source":
```
  if [[ $BIT == x86_64_v3 ]]; then echo "x86_64_v3_ARCH=-DGCC_ARCH=x86-64-v3" >> $GITHUB_ENV; fi
  cmake -DTARGET_ARCH=x86_64-w64-mingw32 -DCOMPILER_TOOLCHAIN=clang  -DCMAKE_INSTALL_PREFIX=$PWD/clang_root -DMINGW_INSTALL_PREFIX=$PWD/build_$BIT/$BIT-w64-mingw32 -DSINGLE_SOURCE_LOCATION=$PWD/src_packages -DRUSTUP_LOCATION=$PWD/clang_root/install_rustup -DENABLE_CCACHE=ON -DCLANG_PACKAGES_LTO=ON -G Ninja --fresh -B build_$BIT -S $PWD
  ninja -C build_$BIT download || true
  shell: bash --noprofile --norc -e -o pipefail {0}
  env:
    BIT: x86_64_v3
    arch: x86_64
    x86_64_level: -v3
```
this may have some trickle down effects on `x86_64_LEVEL` from the main `CMakeLists.txt`:
https://github.com/shinchiro/mpv-winbuild-cmake/blob/8c736232f9c71bf48afcd3aa5d53fc0c3c93a2bf/CMakeLists.txt#L32
which I did not inspect.

in the gcc ci it's set up the same way as this PR, but it's unused there

EDIT:
this renaming of folders is highly likely not needed anymore because `x86_64_LEVEL` is now set properly (have not tested it):
https://github.com/shinchiro/mpv-winbuild-cmake/blob/8c736232f9c71bf48afcd3aa5d53fc0c3c93a2bf/.github/workflows/mpv_clang.yml#L122