### PR TITLE
winpthread: install without strip

### DIFF
--- a/toolchain/mingw-w64-crt.cmake
+++ b/toolchain/mingw-w64-crt.cmake
@@ -16,7 +16,7 @@ ExternalProject_Add(mingw-w64-crt
         ${crt_lib}
         ${cfguard}
     BUILD_COMMAND ${MAKE} LTO=0 GC=0
-    INSTALL_COMMAND ${MAKE} LTO=0 GC=0 install-strip
+    INSTALL_COMMAND ${MAKE} LTO=0 GC=0 install
     LOG_DOWNLOAD 1 LOG_UPDATE 1 LOG_CONFIGURE 1 LOG_BUILD 1 LOG_INSTALL 1
 )
 

--- a/toolchain/winpthreads.cmake
+++ b/toolchain/winpthreads.cmake
@@ -10,7 +10,7 @@ ExternalProject_Add(winpthreads
         --disable-shared
         --enable-static
     BUILD_COMMAND ${MAKE} LTO=0 GC=0
-    INSTALL_COMMAND ${MAKE} LTO=0 GC=0 install-strip
+    INSTALL_COMMAND ${MAKE} LTO=0 GC=0 install
     LOG_CONFIGURE 1 LOG_BUILD 1 LOG_INSTALL 1
 )
 


### PR DESCRIPTION
fixes crash with cfguard enabled