### PR TITLE
libarchive: force use openssl

### DIFF
--- a/packages/libarchive.cmake
+++ b/packages/libarchive.cmake
@@ -12,7 +12,7 @@ ExternalProject_Add(libarchive
     SOURCE_DIR ${SOURCE_LOCATION}
     GIT_CLONE_FLAGS "--filter=tree:0"
     UPDATE_COMMAND ""
-    GIT_RESET de77e6d67166bf667f057bd9515c77bb8dc0f30a
+    PATCH_COMMAND ${EXEC} sed -i [['/^CHECK_CRYPTO/ { /OPENSSL/!d }']] <SOURCE_DIR>/CMakeLists.txt
     CONFIGURE_COMMAND ${EXEC} CONF=1 cmake -H<SOURCE_DIR> -B<BINARY_DIR>
         -G Ninja
         -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
pick from #747 
revert https://github.com/shinchiro/mpv-winbuild-cmake/commit/88643e35032770ed151fb30194a4fa7c950a5e2f