### PR TITLE
fontconfig: rebase patch

### DIFF
--- a/packages/fontconfig-0001-Custom-changes-for-mpv-builds.patch
+++ b/packages/fontconfig-0001-Custom-changes-for-mpv-builds.patch
@@ -1,7 +1,7 @@
-From aa46b1eb3b94e8d2d8d59c361f30a694d8689a81 Mon Sep 17 00:00:00 2001
+From d73d0f1180e9e970ca2f8b57688fc6de5e3045bf Mon Sep 17 00:00:00 2001
 From: shinchiro <shinchiro@users.noreply.github.com>
 Date: Sat, 28 Jun 2025 07:18:49 +0800
-Subject: [PATCH] Custom changes for mpv builds
+Subject: [PATCH 1/2] Custom changes for mpv builds
 
 Based on original lachs0r's patch for fontconfig
 ---
@@ -10,10 +10,10 @@ Based on original lachs0r's patch for fontconfig
  2 files changed, 58 insertions(+), 10 deletions(-)
 
 diff --git a/src/fcdir.c b/src/fcdir.c
-index 9527d94..64cdc5f 100644
+index c17875f..46e4000 100644
 --- a/src/fcdir.c
 +++ b/src/fcdir.c
-@@ -76,11 +76,6 @@ FcFileScanFontConfig (FcFontSet     *set,
+@@ -80,11 +80,6 @@ FcFileScanFontConfig (FcFontSet     *set,
      int            old_nfont = set->nfont;
      const FcChar8 *sysroot = FcConfigGetSysRoot (config);
  
@@ -22,10 +22,10 @@ index 9527d94..64cdc5f 100644
 -	fflush (stdout);
 -    }
 -
-     unsigned int (*query_function) (const FcChar8 *, unsigned int, FcBlanks *, int *, FcFontSet *) = FcFreeTypeQueryAll;
- #if ENABLE_FONTATIONS
-     if (getenv ("FC_FONTATIONS")) {
-@@ -90,9 +85,6 @@ FcFileScanFontConfig (FcFontSet     *set,
+     unsigned int (*query_function) (const FcChar8 *, unsigned int, FcBlanks *, int *, FcFontSet *) =
+ #if ENABLE_FONTATIONS && !defined(ENABLE_FREETYPE)
+     FcFontationsQueryAll;
+@@ -100,9 +95,6 @@ FcFileScanFontConfig (FcFontSet     *set,
      if (!query_function (file, -1, NULL, NULL, set))
  	return FcFalse;
  
@@ -35,7 +35,7 @@ index 9527d94..64cdc5f 100644
      for (i = old_nfont; i < set->nfont; i++) {
  	FcPattern *font = set->fonts[i];
  
-@@ -233,7 +225,7 @@ FcDirScanConfig (FcFontSet     *set,
+@@ -243,7 +235,7 @@ FcDirScanConfig (FcFontSet     *set,
      base = file_prefix + strlen ((char *)file_prefix);
  
      if (FcDebug() & FC_DBG_SCAN)
@@ -44,7 +44,7 @@ index 9527d94..64cdc5f 100644
  
      d = opendir ((char *)s_dir);
      if (!d) {
-@@ -272,8 +264,29 @@ FcDirScanConfig (FcFontSet     *set,
+@@ -282,8 +274,29 @@ FcDirScanConfig (FcFontSet     *set,
      /*
       * Scan file files to build font patterns
       */

--- a/packages/fontconfig-0002-Do-not-use-dirent.h.patch
+++ b/packages/fontconfig-0002-Do-not-use-dirent.h.patch
@@ -1,7 +1,7 @@
-From fb7701e1f00fb9145f0f5b88f7d67fd3931f1e1b Mon Sep 17 00:00:00 2001
+From 7b8ea613515294dd6945de094d095304c1f54ad7 Mon Sep 17 00:00:00 2001
 From: shinchiro <shinchiro@users.noreply.github.com>
 Date: Sat, 6 Apr 2024 11:38:08 +0800
-Subject: [PATCH] Do not use dirent.h
+Subject: [PATCH 2/2] Do not use dirent.h
 
 Because this causes some quirks on some partitions on Windows.
 Relevant issue: https://github.com/mpv-player/mpv/issues/10679
@@ -10,10 +10,10 @@ Relevant issue: https://github.com/mpv-player/mpv/issues/10679
  1 file changed, 1 deletion(-)
 
 diff --git a/meson.build b/meson.build
-index dd3cfe3..be3ea1e 100644
+index 7189f4b..25a4386 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -84,7 +84,6 @@ python3 = import('python').find_installation()
+@@ -97,7 +97,6 @@ python3 = import('python').find_installation()
  pytest = find_program('pytest', required: false)
  
  check_headers = [
@@ -22,5 +22,5 @@ index dd3cfe3..be3ea1e 100644
    ['fcntl.h'],
    ['inttypes.h'],
 -- 
-2.47.0
+2.49.0
 


### PR DESCRIPTION
This should fix a fontconfig patch failure [here](https://github.com/shinchiro/mpv-winbuild-cmake/actions/runs/19996077757/job/57343722915#step:11:150).