### PR TITLE
make building 'stable' stable

### DIFF
--- a/.github/workflows/mpv_clang.yml
+++ b/.github/workflows/mpv_clang.yml
@@ -111,8 +111,13 @@ jobs:
           MPV_TARBALL: ${{ github.event.inputs.mpv_tarball }}
         run: |
           ninja -C build_$BIT update
-          $MPV_TARBALL && ninja -C build_$BIT mpv-release || ninja -C build_$BIT mpv
-          $MPV_TARBALL && echo "mpv_ver=$(cat build_$BIT/packages/mpv-release-prefix/VERSION)" >> $GITHUB_OUTPUT || echo "mpv_ver=UNKNOWN" >> $GITHUB_OUTPUT
+          if [[ "$MPV_TARBALL" == "true" ]]; then
+            ninja -C build_$BIT mpv-release
+            echo "mpv_ver=$(cat build_$BIT/packages/mpv-release-prefix/VERSION)" >> $GITHUB_OUTPUT
+          else
+            ninja -C build_$BIT mpv
+            echo "mpv_ver=UNKNOWN" >> $GITHUB_OUTPUT
+          fi
 
       - name: Packaging mpv
         run: |

--- a/.github/workflows/mpv_clang.yml
+++ b/.github/workflows/mpv_clang.yml
@@ -154,6 +154,7 @@ jobs:
 
       - name: Uploading ${{ matrix.bit }} debug
         uses: actions/upload-artifact@master
+        if: ${{ github.event.inputs.mpv_tarball != 'true' }}
         with:
           name: mpv-${{ matrix.bit }}-debug
           path: release_${{ matrix.bit }}/mpv-debug-${{ env.arch }}*

--- a/.github/workflows/mpv_clang.yml
+++ b/.github/workflows/mpv_clang.yml
@@ -67,7 +67,7 @@ jobs:
 
       - uses: actions/checkout@main
         with:
-          ref: master
+          ref: ${{ github.ref_name }}
 
       - name: Loading clang sysroot cache
         uses: actions/cache/restore@main

--- a/.github/workflows/mpv_clang.yml
+++ b/.github/workflows/mpv_clang.yml
@@ -148,7 +148,9 @@ jobs:
         uses: actions/upload-artifact@master
         with:
           name: mpv-${{ matrix.bit }}
-          path: release_${{ matrix.bit }}/mpv-${{ env.arch }}*
+          path: |
+            release_${{ matrix.bit }}/mpv-${{ env.arch }}*.7z
+            release_${{ matrix.bit }}/mpv-*-${{ env.arch }}*.7z
 
       - name: Uploading ${{ matrix.bit }} debug
         uses: actions/upload-artifact@master

--- a/packages/mpv-packaging.cmake
+++ b/packages/mpv-packaging.cmake
@@ -7,7 +7,7 @@ if [ -d $dir ] && [[ $dir =~ mpv-$3.*-git-* ]]; then
     cp -r $1/mpv-root/* $1/$3/d3dcompiler_43.dll $dir
     7z a -m0=lzma2 -mx=9 -ms=on $dir.7z $dir/* -x!*.7z
 elif [ -d $dir ] && [[ $dir =~ mpv-.*$3$ ]]; then
-    cp -r $1/mpv-root/mpv $1/mpv-root/fonts $1/$3/d3dcompiler_43.dll $dir
+    cp -r $1/mpv-root/* $1/$3/d3dcompiler_43.dll $dir
     7z a -m0=lzma2 -mx=9 -ms=on $dir.7z $dir/* -x!*.7z
 elif [ -d $dir ]; then
     7z a -m0=lzma2 -mx=9 -ms=on $dir.7z $dir/* -x!*.7z

--- a/packages/mpv-packaging.cmake
+++ b/packages/mpv-packaging.cmake
@@ -7,7 +7,7 @@ if [ -d $dir ] && [[ $dir =~ mpv-$3.*-git-* ]]; then
     cp -r $1/mpv-root/* $1/$3/d3dcompiler_43.dll $dir
     7z a -m0=lzma2 -mx=9 -ms=on $dir.7z $dir/* -x!*.7z
 elif [ -d $dir ] && [[ $dir =~ mpv-.*$3 ]] && [[ ! $dir =~ -git- ]]; then
-    cp -r $1/mpv-root/* $1/$3/d3dcompiler_43.dll $dir
+    cp -r $1/mpv-root/installer $1/mpv-root/doc $1/$3/d3dcompiler_43.dll $dir
     7z a -m0=lzma2 -mx=9 -ms=on $dir.7z $dir/* -x!*.7z
 elif [ -d $dir ]; then
     7z a -m0=lzma2 -mx=9 -ms=on $dir.7z $dir/* -x!*.7z

--- a/packages/mpv-packaging.cmake
+++ b/packages/mpv-packaging.cmake
@@ -6,7 +6,7 @@ for dir in $2/mpv*$3*; do
 if [ -d $dir ] && [[ $dir =~ mpv-$3.*-git-* ]]; then
     cp -r $1/mpv-root/* $1/$3/d3dcompiler_43.dll $dir
     7z a -m0=lzma2 -mx=9 -ms=on $dir.7z $dir/* -x!*.7z
-elif [ -d $dir ] && [[ $dir =~ mpv-.*$3$ ]]; then
+elif [ -d $dir ] && [[ $dir =~ mpv-.*$3 ]] && [[ ! $dir =~ -git- ]]; then
     cp -r $1/mpv-root/* $1/$3/d3dcompiler_43.dll $dir
     7z a -m0=lzma2 -mx=9 -ms=on $dir.7z $dir/* -x!*.7z
 elif [ -d $dir ]; then

--- a/packages/mpv-packaging.cmake
+++ b/packages/mpv-packaging.cmake
@@ -7,7 +7,9 @@ if [ -d $dir ] && [[ $dir =~ mpv-$3.*-git-* ]]; then
     cp -r $1/mpv-root/* $1/$3/d3dcompiler_43.dll $dir
     7z a -m0=lzma2 -mx=9 -ms=on $dir.7z $dir/* -x!*.7z
 elif [ -d $dir ] && [[ $dir =~ mpv-.*$3 ]] && [[ ! $dir =~ -git- ]]; then
-    cp -r $1/mpv-root/installer $1/mpv-root/doc $1/$3/d3dcompiler_43.dll $dir
+    mkdir -p $dir/installer
+    cp $1/mpv-root/installer/mpv-install.bat $1/mpv-root/installer/mpv-uninstall.bat $1/mpv-root/installer/mpv-icon.ico $dir/installer
+    cp -r $1/mpv-root/doc $1/$3/d3dcompiler_43.dll $dir
     7z a -m0=lzma2 -mx=9 -ms=on $dir.7z $dir/* -x!*.7z
 elif [ -d $dir ]; then
     7z a -m0=lzma2 -mx=9 -ms=on $dir.7z $dir/* -x!*.7z

--- a/packages/mpv-release.cmake
+++ b/packages/mpv-release.cmake
@@ -13,6 +13,15 @@ file(COPY ${PREFIX_DIR}/get_latest_tag.sh
 execute_process(COMMAND ${PREFIX_DIR}/src/get_latest_tag.sh
                 OUTPUT_VARIABLE LINK)
 
+# Force the build+install chain to re-run every cmake configure. The workflow
+# cleans build_$BIT/mpv* after packaging, which removes the output folder
+# (mpv-<TAG>-<arch>/) but leaves ExternalProject stamps intact in the toolchain
+# cache. Without this, ninja skips build/copy steps on subsequent runs, leaving
+# no folder for the packaging script to archive.
+foreach(_stamp build install strip-binary copy-binary copy-versionfile copy-package-dir)
+    file(REMOVE ${PREFIX_DIR}/src/mpv-release-stamp/mpv-release-${_stamp})
+endforeach()
+
 # Wrapper around `meson setup` that drops any -D<name>=<value> whose <name>
 # is not declared in the tarball's meson.options/meson_options.txt. Lets us
 # build older stable releases even after master adds new meson options.

--- a/packages/mpv-release.cmake
+++ b/packages/mpv-release.cmake
@@ -114,4 +114,5 @@ ExternalProject_Add_Step(mpv-release copy-package-dir
     LOG 1
 )
 
+force_meson_configure(mpv-release)
 cleanup(mpv-release copy-package-dir)

--- a/packages/mpv-release.cmake
+++ b/packages/mpv-release.cmake
@@ -13,6 +13,46 @@ file(COPY ${PREFIX_DIR}/get_latest_tag.sh
 execute_process(COMMAND ${PREFIX_DIR}/src/get_latest_tag.sh
                 OUTPUT_VARIABLE LINK)
 
+# Wrapper around `meson setup` that drops any -D<name>=<value> whose <name>
+# is not declared in the tarball's meson.options/meson_options.txt. Lets us
+# build older stable releases even after master adds new meson options.
+file(WRITE ${PREFIX_DIR}/meson_setup_filtered.sh
+"#!/bin/bash
+set -e
+SRC=\"$1\"; shift
+BUILD=\"$1\"; shift
+
+OPTS_FILE=\"\"
+for f in \"$SRC/meson.options\" \"$SRC/meson_options.txt\"; do
+  [ -f \"$f\" ] && { OPTS_FILE=\"$f\"; break; }
+done
+
+if [ -z \"$OPTS_FILE\" ]; then
+  echo \"meson_setup_filtered.sh: no options file in $SRC; passing through\" >&2
+  exec meson setup \"$BUILD\" \"$SRC\" \"$@\"
+fi
+
+KNOWN=$(perl -0777 -ne 'while(/option\\s*\\(\\s*[\\x27\\x22]([a-zA-Z0-9_-]+)[\\x27\\x22]/g){print \"$1\\n\"}' \"$OPTS_FILE\")
+
+FILTERED=()
+for arg in \"$@\"; do
+  if [[ \"$arg\" =~ ^-D([a-zA-Z0-9_-]+)= ]]; then
+    name=\"\${BASH_REMATCH[1]}\"
+    if ! grep -qx \"$name\" <<< \"$KNOWN\"; then
+      echo \"meson_setup_filtered.sh: skipping unsupported -D$name (not in $OPTS_FILE)\" >&2
+      continue
+    fi
+  fi
+  FILTERED+=(\"$arg\")
+done
+
+exec meson setup \"$BUILD\" \"$SRC\" \"\${FILTERED[@]}\"
+")
+
+file(COPY ${PREFIX_DIR}/meson_setup_filtered.sh
+     DESTINATION ${PREFIX_DIR}/src
+     FILE_PERMISSIONS OWNER_EXECUTE OWNER_READ)
+
 ExternalProject_Add(mpv-release
     DEPENDS
         angle-headers
@@ -41,7 +81,7 @@ ExternalProject_Add(mpv-release
         libsixel
     URL ${LINK}
     SOURCE_DIR ${SOURCE_LOCATION}
-    CONFIGURE_COMMAND ${EXEC} CONF=1 meson setup <BINARY_DIR> <SOURCE_DIR>
+    CONFIGURE_COMMAND ${EXEC} CONF=1 bash ${PREFIX_DIR}/src/meson_setup_filtered.sh <SOURCE_DIR> <BINARY_DIR>
         --prefix=${MINGW_INSTALL_PREFIX}
         --libdir=${MINGW_INSTALL_PREFIX}/lib
         --cross-file=${MESON_CROSS}


### PR DESCRIPTION
Of course, from mpv's perspective, nightly builds are stable enough. But tagged releases are naturally perceived as "stable" by regular users, and the `mpv_tarball` option in `mpv_clang` had several issues that made it unreliable. These fixes make it actually work.

btw, I did not do anything about mpv_gcc.