### PR TITLE
libsixel: fix HAVE_TESTS is defined even with --disable-tests

### DIFF
--- a/packages/libsixel.cmake
+++ b/packages/libsixel.cmake
@@ -4,7 +4,6 @@ ExternalProject_Add(libsixel
     GIT_CLONE_FLAGS "--sparse --filter=tree:0"
     GIT_CLONE_POST_COMMAND "sparse-checkout set --no-cone /* !images"
     UPDATE_COMMAND ""
-    GIT_RESET af12e5bc6f3f69ad83479da85ddb371420da9b17
     CONFIGURE_COMMAND ${EXEC} <SOURCE_DIR>/autogen.sh && CONF=1 <SOURCE_DIR>/configure
         --host=${TARGET_ARCH}
         --prefix=${MINGW_INSTALL_PREFIX}
@@ -12,7 +11,6 @@ ExternalProject_Add(libsixel
         --disable-sixel2png
         --disable-python
         --disable-shared
-        --disable-tests
         --enable-static
     BUILD_COMMAND ${MAKE}
     INSTALL_COMMAND ${MAKE} install


### PR DESCRIPTION
Glad to see you back in action, @shinchiro.

While you were gone, I encountered this issue as well. It seems there is a bug in `libsixel`'s `configure.ac`: `HAVE_DEBUG` is defined even when a user runs `./configure --disable-debug`.
Since `HAVE_DEBUG` is not defined by default, we could just not specify ` --disable-debug` as a workaround.