### PR TITLE
Pin gcc to a release tarball

### DIFF
--- a/toolchain/gcc/gcc.cmake
+++ b/toolchain/gcc/gcc.cmake
@@ -1,9 +1,8 @@
 ExternalProject_Add(gcc
     DEPENDS
         mingw-w64-headers
-    URL https://mirrorservice.org/sites/sourceware.org/pub/gcc/snapshots/14-20251205/gcc-14-20251205.tar.xz
-    # https://mirrorservice.org/sites/sourceware.org/pub/gcc/snapshots/13-20240309/sha512.sum
-    URL_HASH SHA512=b05c932de5c478cf9b64a4f2cbdf1de9b37a4845614ff8bc0e0563cd1e716f69ea0fe070ef9bf5ec1fccc0658705ec76cef536ac8dc4ca4c32cf81dad8588c37
+    URL https://ftp.gnu.org/gnu/gcc/gcc-14.4.0/gcc-14.4.0.tar.xz
+    URL_HASH SHA512=725ed8bdd43ef1726ffe8b5e8615a13e247fac9575b7626ae013a2975d000ea213212dc414b2f2631ac4785c1c8beca85555222faf9904d3b2fa6a3807a83a15
     DOWNLOAD_DIR ${SOURCE_LOCATION}
     CONFIGURE_COMMAND <SOURCE_DIR>/configure
         --target=${TARGET_ARCH}


### PR DESCRIPTION
The pinned snapshot predates the `__cpp_char8_t` guard in libcody, so `u8" "` deduces as `char8_t[]` and libcody fails to compile on hosts that now default to C++20 — the archlinux container's gcc 16 does. Snapshots also get pruned from sourceware eventually.

14.4.0 has the guard, and the ftp.gnu.org URL is permanent. Verified by building the x86_64-w64-mingw32 toolchain in ghcr.io/shinchiro/archlinux:latest.