### PR TITLE
Drop --enable-libshaderc, removed from ffmpeg

### DIFF
--- a/packages/ffmpeg.cmake
+++ b/packages/ffmpeg.cmake
@@ -100,7 +100,6 @@ ExternalProject_Add(ffmpeg
         --enable-libvpl
         --enable-libjxl
         --enable-libplacebo
-        --enable-libshaderc
         --enable-libzvbi
         --enable-libaribcaption
         ${ffmpeg_cuda}


### PR DESCRIPTION
ffmpeg replaced the libshaderc dependency with a build-time probe for a `glslc` or `glslangValidator` binary, so configure now aborts with `Unknown option "--enable-libshaderc"` and every build against master stops there.

Removing the flag is enough; the shaderc package is still needed for libplacebo. Verified by configuring ffmpeg at 946272b79 in the gcc toolchain.